### PR TITLE
Branch optimization

### DIFF
--- a/pykwasm/src/pykwasm/kdist/wasm-semantics/auxil.md
+++ b/pykwasm/src/pykwasm/kdist/wasm-semantics/auxil.md
@@ -30,8 +30,7 @@ module WASM-AUXIL
          <nextModuleIdx>     _ => 0         </nextModuleIdx>
          <moduleRegistry>    _ => .Map      </moduleRegistry>
          <mainStore>
-           <sizelblInst>     _ => 0         </sizelblInst>
-           <labels>          _ => .Bag      </labels>
+           <labels>          _ => .List    </labels>
            <nextFuncAddr>    _ => 0         </nextFuncAddr>
            <funcs>           _ => .Bag      </funcs>
            <nextTabAddr>     _ => 0         </nextTabAddr>

--- a/pykwasm/src/pykwasm/kdist/wasm-semantics/auxil.md
+++ b/pykwasm/src/pykwasm/kdist/wasm-semantics/auxil.md
@@ -30,6 +30,8 @@ module WASM-AUXIL
          <nextModuleIdx>     _ => 0         </nextModuleIdx>
          <moduleRegistry>    _ => .Map      </moduleRegistry>
          <mainStore>
+           <sizelblInst>     _ => 0         </sizelblInst>
+           <labels>          _ => .Bag      </labels>
            <nextFuncAddr>    _ => 0         </nextFuncAddr>
            <funcs>           _ => .Bag      </funcs>
            <nextTabAddr>     _ => 0         </nextTabAddr>

--- a/pykwasm/src/pykwasm/kdist/wasm-semantics/wasm.md
+++ b/pykwasm/src/pykwasm/kdist/wasm-semantics/wasm.md
@@ -332,7 +332,7 @@ Thus, a `trap` "bubbles up" (more correctly, to "consumes the continuation") unt
 ```k
     syntax Instr ::= "trap"
  // -----------------------
-    rule <instrs> trap ~> (_L:Label => .K) ... </instrs>
+    rule <instrs> trap ~> label _ {_} _ KCELL ~> _ => (trap ~> KCELL) </instrs>
     rule <instrs> trap ~> (_F:Frame => .K) ... </instrs>
     rule <instrs> trap ~> (_I:Instr => .K) ... </instrs>
     rule <instrs> trap ~> (_D:Defn  => .K) ... </instrs>
@@ -1207,7 +1207,7 @@ The `#take` function will return the parameter stack in the reversed order, then
          </funcDef>
 
     rule <instrs> return ~> (_S:Stmt  => .K)  ... </instrs>
-    rule <instrs> return ~> (_L:Label => .K)  ... </instrs>
+    rule <instrs> return ~> (label [_] {_} _ KCELL) ~> _ => (return ~> KCELL) </instrs>
     rule <instrs> (return => .K) ~> _FR:Frame ... </instrs>
 ```
 

--- a/pykwasm/src/pykwasm/kdist/wasm-semantics/wasm.md
+++ b/pykwasm/src/pykwasm/kdist/wasm-semantics/wasm.md
@@ -516,15 +516,24 @@ Note that, unlike in the WebAssembly specification document, we do not need the 
 ```k
     syntax Instr ::= #br( Int ) [symbol(aBr)] | "#br_aux" "(" Int ")" [symbol(aBr_aux)]
  // -------------------------------------------------
-     rule <instrs> #br(0   ) ~> label [ TYPES ] { IS } VALSTACK' => sequenceInstrs(IS) ... </instrs>
-          <valstack> VALSTACK => #take(lengthValTypes(TYPES), VALSTACK) ++ VALSTACK' </valstack>
+    rule <instrs> #br(_IDX) ~> (_S:Stmt => .K) ... </instrs>
+    rule <instrs> #br(0   ) ~> label [ TYPES ] { IS } VALSTACK' => sequenceInstrs(IS) ... </instrs>
+         <valstack> VALSTACK => #take(lengthValTypes(TYPES), VALSTACK) ++ VALSTACK' </valstack>
+
+
     rule <instrs> #br(N:Int) ~> _L:Label => #br_aux(SIZE -Int N -Int 1) ... </instrs>
          <sizelblInst> SIZE </sizelblInst>
       requires N >Int 0
 
     rule <instrs> #br_aux(_IDX) ~> (_S:Stmt => .K) ... </instrs>
 
-    rule <instrs> #br_aux(N:Int) ~> _L:Label => #br_aux(N:Int) ... </instrs>    
+    rule <instrs> #br_aux(N:Int) ~> _L:Label => sequenceInstrs(IS) ... </instrs>
+         <labelsInstance>
+            <idxLabel> N </idxLabel>
+            <label> label [ TYPES ] { IS } VALSTACK' </label>
+         </labelsInstance>
+         <valstack> VALSTACK => #take(lengthValTypes(TYPES), VALSTACK) ++ VALSTACK' </valstack>
+    
     rule <instrs> #br_aux(N:Int) => sequenceInstrs(IS) ... </instrs>
          <labelsInstance>
             <idxLabel> N </idxLabel>

--- a/pykwasm/src/pykwasm/kdist/wasm-semantics/wasm.md
+++ b/pykwasm/src/pykwasm/kdist/wasm-semantics/wasm.md
@@ -569,16 +569,46 @@ Finally, we have the conditional and loop instructions.
  // ------------------------------------------------------------------------------------------------------------
     rule <instrs> #if(VECTYP, IS, _, _)  => sequenceInstrs(IS) ~> label VECTYP { .Instrs } VALSTACK ... </instrs>
          <valstack> < i32 > VAL : VALSTACK => VALSTACK </valstack>
+         <sizelblInst> NEXTID => NEXTID +Int 1 </sizelblInst>
+         <labels>
+          (.Bag
+          => <labelsInstance>
+            <idxLabel> NEXTID </idxLabel>
+            <label> (label VECTYP { .Instrs } VALSTACK) </label>
+          </labelsInstance>
+         )
+         ...
+         </labels>
       requires VAL =/=Int 0
 
     rule <instrs> #if(VECTYP, _, IS, _) => sequenceInstrs(IS) ~> label VECTYP { .Instrs } VALSTACK ... </instrs>
          <valstack> < i32 > VAL : VALSTACK => VALSTACK </valstack>
+         <sizelblInst> NEXTID => NEXTID +Int 1 </sizelblInst>
+         <labels>
+          (.Bag
+          => <labelsInstance>
+            <idxLabel> NEXTID </idxLabel>
+            <label> (label VECTYP { .Instrs } VALSTACK) </label>
+          </labelsInstance>
+         )
+         ...
+         </labels>
       requires VAL ==Int 0
 
     syntax Instr ::= #loop(VecType, Instrs, BlockMetaData) [symbol(aLoop)]
  // ------------------------------------------------------------------------------
     rule <instrs> #loop(VECTYP, IS, BLOCKMETA) => sequenceInstrs(IS) ~> label VECTYP { #loop(VECTYP, IS, BLOCKMETA) } VALSTACK ... </instrs>
          <valstack> VALSTACK => .ValStack </valstack>
+         <sizelblInst> NEXTID => NEXTID +Int 1 </sizelblInst>
+         <labels>
+          (.Bag
+          => <labelsInstance>
+            <idxLabel> NEXTID </idxLabel>
+            <label> (label VECTYP { #loop(VECTYP, IS, BLOCKMETA) } VALSTACK) </label>
+          </labelsInstance>
+         )
+         ...
+         </labels>
 ```
 
 Variable Operators

--- a/pykwasm/src/pykwasm/kdist/wasm-semantics/wasm.md
+++ b/pykwasm/src/pykwasm/kdist/wasm-semantics/wasm.md
@@ -476,7 +476,7 @@ A block is the simplest way to create targets for break instructions (ie. jump d
 It simply executes the block then records a label with an empty continuation.
 
 ```k
-    syntax Label ::= "label" VecType "{" Instrs "}" ValStack K | ".Label"
+    syntax Label ::= "label" VecType "{" Instrs "}" ValStack K
  // --------------------------------------------------------
     rule <instrs> label [ TYPES ] { IS } VALSTACK' KCELL => KCELL </instrs>
          <valstack> VALSTACK => #take(lengthValTypes(TYPES), VALSTACK) ++ VALSTACK' </valstack>
@@ -1207,8 +1207,9 @@ The `#take` function will return the parameter stack in the reversed order, then
          </funcDef>
 
     rule <instrs> return ~> (_S:Stmt  => .K)  ... </instrs>
-    rule <instrs> return ~> (label [_] {_} _ KCELL) ~> _ => (return ~> KCELL) </instrs>
-    rule <instrs> (return => .K) ~> _FR:Frame ... </instrs>
+    rule <instrs> return ~> (label [_] {_} _ KCELL ~> _) => (return ~> KCELL) </instrs>
+    rule <instrs> return ~> _FR:Frame ~> (label [_] {_} _ KCELL) ~> _ => (return ~> KCELL) </instrs>
+    rule <instrs> (return => .K) ~> _FR:Frame ... </instrs> [owise]
 ```
 
 ### Function Call

--- a/tests/success-llvm.out
+++ b/tests/success-llvm.out
@@ -30,6 +30,9 @@
       0
     </nextModuleIdx>
     <mainStore>
+      <labels>
+        .List
+      </labels>
       <funcs>
         .FuncDefCellMap
       </funcs>


### PR DESCRIPTION
FIX: [#1588](https://github.com/Pi-Squared-Inc/pi2/issues/1588)

This PR implements a branch continuation optimization. Previously, we were popping values in the `<instrs>` cell once we found a `br` instruction without a label after it, and once we found a label if the `IDX` of the br instruction wasn't `0`, we rewrote it until reaching the base case. This was fairly time-consuming and inefficient.

This new optimization addresses the two issues by sacrificing space efficiency. Here, we introduce a new K list cell, `labels`, which contains the whole state continuation of a block. So, right now, instead of popping instructions, we just replace the whole `<instr>` cell, and instead of rewriting the `br` instruction until it reaches the base case, we just use the list index to "jump" to the correct block and pop the others using the `range` hook.

So, in programs that don't have many changes in control flow, we may have some slowdown. However, for programs that contain such cases, we expect to see some great speedups. 