### PR TITLE
Use MInt instead of Int for most integer arithmetic

### DIFF
--- a/pykwasm/src/pykwasm/kdist/plugin.py
+++ b/pykwasm/src/pykwasm/kdist/plugin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+from fractions import Fraction
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -60,6 +61,7 @@ __TARGETS__: Final = {
             'warnings_to_errors': True,
             'gen_glr_bison_parser': True,
             'opt_level': 3,
+            'iterated_threshold': Fraction(1),
             'ccopts': ['-g'],
         },
     ),

--- a/pykwasm/src/pykwasm/kdist/wasm-semantics/data.md
+++ b/pykwasm/src/pykwasm/kdist/wasm-semantics/data.md
@@ -258,6 +258,16 @@ The sort `OptionalInt` provides this potentially "undefined" `Int`.
 
 ```
 
+### Integer conversion
+
+```k
+    syntax MInt{32} ::= i2i32(Int) [function]
+    syntax MInt{64} ::= i2i64(Int) [function]
+ // -----------------------------------------
+    rule i2i32(I) => Int2MInt(I)
+    rule i2i64(I) => Int2MInt(I)
+```
+
 ```k
 endmodule
 ```

--- a/pykwasm/src/pykwasm/kdist/wasm-semantics/data/list-ref.k
+++ b/pykwasm/src/pykwasm/kdist/wasm-semantics/data/list-ref.k
@@ -4,6 +4,7 @@ module LIST-REF
   imports WASM-DATA-INTERNAL-SYNTAX
   imports private INT-SYNTAX
   imports private BASIC-K
+  imports private MINT-SYNTAX
 
   syntax Int
 
@@ -24,8 +25,8 @@ module LIST-REF
           ]
   syntax RefVal ::= ListRef "[" Int "]"
           [ function, hook(LIST.get), symbol(ListRef:get) ]
-  syntax ListRef ::= ListRef "[" index: Int "<-" value: RefVal "]"
-          [function, hook(LIST.update), symbol(ListRef:set)]
+  syntax ListRef ::= ListRef "[" index: MInt{64} "<-" value: RefVal "]"
+          [function, hook(LIST.update_long), symbol(ListRef:set)]
   syntax ListRef ::= makeListRef(length: Int, value: RefVal)
           [function, hook(LIST.make)]
   syntax ListRef ::= updateList(dest: ListRef, index: Int, src: ListRef)
@@ -36,53 +37,53 @@ module LIST-REF
           [function, hook(LIST.range), symbol(ListRef:range)]
   syntax Bool ::= RefVal "in" ListRef
           [function, total, hook(LIST.in), symbol(_inListRef_)]
-  syntax Int ::= size(ListRef)
-          [function, total, hook(LIST.size), symbol(sizeListRef), smtlib(smt_seq_len)]
+  syntax MInt{64} ::= size(ListRef)
+          [function, total, hook(LIST.size_long), symbol(sizeListRef), smtlib(smt_seq_len)]
 endmodule
 
 module LIST-REF-EXTENSIONS
   imports LIST-REF
   imports BOOL
   imports INT
+  imports MINT
 
-  syntax RefVal ::= ListRef "[" Int "]" "orDefault" RefVal
+  syntax RefVal ::= ListRef "[" MInt{64} "]" "orDefault" RefVal
           [ function, total, symbol(ListRef:getOrDefault) ]
 // ----------------------------------------------------------------
-  rule ListItem(V:RefVal) _:ListRef [0] orDefault _:RefVal
+  rule ListItem(V:RefVal) _:ListRef [N] orDefault _:RefVal
       => V
-  rule _:ListRef ListItem(V:RefVal) [-1] orDefault _:RefVal
+    requires N ==MInt 0p64
+  rule _:ListRef ListItem(V:RefVal) [N] orDefault _:RefVal
       => V
-  rule .ListRef [_:Int] orDefault D:RefVal => D
+    requires N ==MInt -1p64
+  rule .ListRef [_:MInt{64}] orDefault D:RefVal => D
 
-  rule ListItem(_:RefVal) L:ListRef [I:Int] orDefault D:RefVal
-      => L[I -Int 1] orDefault D
-    requires 0 <Int I
-  rule L:ListRef ListItem(_:RefVal) [I:Int] orDefault D:RefVal
-      => L[I +Int 1] orDefault D
-    requires I <Int 0
+  rule ListItem(_:RefVal) L:ListRef [I:MInt{64}] orDefault D:RefVal
+      => L[I -MInt 1p64] orDefault D
+    requires 0p64 <sMInt I
+  rule L:ListRef ListItem(_:RefVal) [I:MInt{64}] orDefault D:RefVal
+      => L[I +MInt 1p64] orDefault D
+    requires I <sMInt 0p64
 
-  rule L:ListRef[I:Int] orDefault D:RefVal => D
-    requires notBool (0 -Int size(L) <=Int I andBool I <Int size(L))
+  rule L:ListRef[I:MInt{64}] orDefault D:RefVal => D
+    requires notBool (0p64 -MInt size(L)) <=sMInt I andBool I <sMInt size(L)
     [simplification]
 
-  syntax RefVal ::= getRefOrNull(ListRef, Int)
+  syntax RefVal ::= getRefOrNull(ListRef, MInt{64})
           [ function, total, symbol(ListRef:getOrNull) ]
 // -------------------------------------------------------------
   rule getRefOrNull(L, N) => L [N] orDefault (<funcref> null)
 
-  syntax ListRef ::= makeListRefTotal(Int, RefVal)
+  syntax ListRef ::= makeListRefTotal(MInt{32}, RefVal)
       [function, total, symbol(ListRef:makeTotal)]
 // ----------------------------------------------------
-  rule makeListRefTotal(N, V) => makeListRef(N, V)
-    requires N >=Int 0
-  rule makeListRefTotal(N, _) => .ListRef
-    requires N <Int 0
+  rule makeListRefTotal(N, V) => makeListRef(MInt2Unsigned(N), V)
   
-  syntax ListRef ::= dropListRef(Int, ListRef)
+  syntax ListRef ::= dropListRef(MInt{32}, ListRef)
       [function, total, symbol(ListRef:drop)]
 // --------------------------------------------------------------
-  rule dropListRef(N, ListItem(_) L) => dropListRef(N -Int 1, L)
-    requires N >Int 0
+  rule dropListRef(N, ListItem(_) L) => dropListRef(N -MInt 1p32, L)
+    requires N =/=MInt 0p32
   rule dropListRef(_, L)             => L
     [owise]
   

--- a/pykwasm/src/pykwasm/kdist/wasm-semantics/wasm.md
+++ b/pykwasm/src/pykwasm/kdist/wasm-semantics/wasm.md
@@ -344,7 +344,7 @@ If the value is the special `undefined`, then `trap` is generated instead.
     rule <instrs> undefined => trap ... </instrs>
     rule <instrs>   V:Val    => .K       ... </instrs>
          <valstack> VALSTACK => V : VALSTACK </valstack>
-      requires V =/=K undefined
+    [owise]
 ```
 
 Common Operator Machinery

--- a/tests/simple/arithmetic.wast
+++ b/tests/simple/arithmetic.wast
@@ -1,27 +1,27 @@
 (i32.const 5)
 (i32.const 7)
 (i32.add)
-#assertTopStack < i32 > 12 "add"
+#assertTopStack < i32 > i2i32(12) "add"
 
 (i32.const 5)
 (i32.const 7)
 (i32.sub)
-#assertTopStack < i32 > -2 "sub"
+#assertTopStack < i32 > i2i32(-2) "sub"
 
 (i32.const 15)
 (i32.const 3)
 (i32.mul)
-#assertTopStack < i32 > 45 "mul"
+#assertTopStack < i32 > i2i32(45) "mul"
 
 (i32.const 15)
 (i32.const 3)
 (i32.div_u)
-#assertTopStack < i32 > 5 "div_u1"
+#assertTopStack < i32 > i2i32(5) "div_u1"
 
 (i32.const 15)
 (i32.const 2)
 (i32.div_u)
-#assertTopStack < i32 > 7 "div_u2"
+#assertTopStack < i32 > i2i32(7) "div_u2"
 
 (i32.const 15)
 (i32.const 0)
@@ -31,12 +31,12 @@
 (i32.const 15)
 (i32.const 3)
 (i32.rem_u)
-#assertTopStack < i32 > 0 "rem_u1"
+#assertTopStack < i32 > i2i32(0) "rem_u1"
 
 (i32.const 15)
 (i32.const 2)
 (i32.rem_u)
-#assertTopStack < i32 > 1 "rem_u2"
+#assertTopStack < i32 > i2i32(1) "rem_u2"
 
 (i32.const 15)
 (i32.const 0)
@@ -46,137 +46,137 @@
 (i32.const 10)
 (i32.const 3)
 (i32.div_s)
-#assertTopStack < i32 > 3 "i32.div_s 1"
+#assertTopStack < i32 > i2i32(3) "i32.div_s 1"
 
 (i32.const 10)
 (i32.const 4)
 (i32.div_s)
-#assertTopStack < i32 > 2 "i32.div_s 2"
+#assertTopStack < i32 > i2i32(2) "i32.div_s 2"
 
 (i32.const 10)
 (i32.const 0)
 (i32.div_s)
 #assertTrap "i32.div_s 3"
 
-(i32.const #pow1(i32))
-(i32.sub (i32.const #pow(i32)) (i32.const 1))
+(i32.const 2147483648)
+(i32.sub (i32.const 4294967296) (i32.const 1))
 (i32.div_s)
 #assertTrap "i32.div_s 4"
 
 (i32.const 10)
 (i32.const 5)
 (i32.div_s)
-#assertTopStack < i32 > 2 "div_s"
+#assertTopStack < i32 > i2i32(2) "div_s"
 
 (i32.const 91)
 (i32.const 13)
 (i32.rem_s)
-#assertTopStack <i32 > 0 "rem_s"
+#assertTopStack <i32 > i2i32(0) "rem_s"
 
 (i32.const -91)
 (i32.const -13)
 (i32.rem_s)
-#assertTopStack <i32 > 0 "rem_s"
+#assertTopStack <i32 > i2i32(0) "rem_s"
 
 (i32.const -1)
 (i32.const -3)
 (i32.rem_s)
-#assertTopStack <i32 > -1 "rem_s"
+#assertTopStack <i32 > i2i32(-1) "rem_s"
 
 (i32.const 10)
 (i32.const 0)
 (i32.rem_s)
 #assertTrap "rem_s"
 
-(i32.const #pow1(i32))
-(i32.sub (i32.const #pow(i32)) (i32.const 1))
+(i32.const 2147483648)
+(i32.sub (i32.const 4294967296) (i32.const 1))
 (i32.rem_s)
-#assertTopStack <i32 > 0 "rem_s edge case"
+#assertTopStack <i32 > i2i32(0) "rem_s edge case"
 
 ;; The following tests were generated using the reference OCaml WASM interpreter.
 
 (i32.const 10)
 (i32.const 3)
 (i32.rem_s)
-#assertTopStack < i32 > 1 "i32.rem_s 1"
+#assertTopStack < i32 > i2i32(1) "i32.rem_s 1"
 
 (i32.const 10)
 (i32.const 4)
 (i32.rem_s)
-#assertTopStack < i32 > 2 "i32.rem_s 2"
+#assertTopStack < i32 > i2i32(2) "i32.rem_s 2"
 
 (i32.const 10)
 (i32.const 5)
 (i32.rem_s)
-#assertTopStack < i32 > 0 "i32.rem_s 3"
+#assertTopStack < i32 > i2i32(0) "i32.rem_s 3"
 
 (i32.const -10)
 (i32.const 3)
 (i32.div_s)
-#assertTopStack < i32 > -3 "i32.div_s 3"
+#assertTopStack < i32 > i2i32(-3) "i32.div_s 3"
 
 (i32.const -10)
 (i32.const 4)
 (i32.div_s)
-#assertTopStack < i32 > -2 "i32.div_s 4"
+#assertTopStack < i32 > i2i32(-2) "i32.div_s 4"
 
 (i32.const -10)
 (i32.const 5)
 (i32.div_s)
-#assertTopStack < i32 > -2 "i32.div_s 5"
+#assertTopStack < i32 > i2i32(-2) "i32.div_s 5"
 
 (i32.const -10)
 (i32.const 3)
 (i32.rem_s)
-#assertTopStack < i32 > -1 "i32.rem_s 4"
+#assertTopStack < i32 > i2i32(-1) "i32.rem_s 4"
 
 (i32.const -10)
 (i32.const 4)
 (i32.rem_s)
-#assertTopStack < i32 > -2 "i32.rem_s 5"
+#assertTopStack < i32 > i2i32(-2) "i32.rem_s 5"
 
 (i32.const -10)
 (i32.const 5)
 (i32.rem_s)
-#assertTopStack < i32 > 0 "i32.rem_s 6"
+#assertTopStack < i32 > i2i32(0) "i32.rem_s 6"
 
 (i32.const -10)
 (i32.const -3)
 (i32.div_s)
-#assertTopStack < i32 > 3 "i32.div_s 6"
+#assertTopStack < i32 > i2i32(3) "i32.div_s 6"
 
 (i32.const -10)
 (i32.const -4)
 (i32.div_s)
-#assertTopStack < i32 > 2 "i32.div_s 7"
+#assertTopStack < i32 > i2i32(2) "i32.div_s 7"
 
 (i32.const -10)
 (i32.const -5)
 (i32.div_s)
-#assertTopStack < i32 > 2 "i32.div_s 8"
+#assertTopStack < i32 > i2i32(2) "i32.div_s 8"
 
 (i32.const -10)
 (i32.const -3)
 (i32.rem_s)
-#assertTopStack < i32 > -1 "i32.rem_s 7"
+#assertTopStack < i32 > i2i32(-1) "i32.rem_s 7"
 
 (i32.const -10)
 (i32.const -4)
 (i32.rem_s)
-#assertTopStack < i32 > -2 "i32.rem_s 8"
+#assertTopStack < i32 > i2i32(-2) "i32.rem_s 8"
 
 (i32.const -10)
 (i32.const -5)
 (i32.rem_s)
-#assertTopStack < i32 > 0 "i32.rem_s 9"
+#assertTopStack < i32 > i2i32(0) "i32.rem_s 9"
 
 (i32.add (i32.const 3) (i32.const 4))
-#assertTopStack < i32 > 7 "simple add folded"
+#assertTopStack < i32 > i2i32(7) "simple add folded"
 
 (i32.sub (i32.const 3) (i32.const 4))
-#assertTopStack < i32 > -1 "simple sub, order dependent folded"
+#assertTopStack < i32 > i2i32(-1) "simple sub, order dependent folded"
 
 (i32.sub (i32.mul (i32.const 5) (i32.const 7)) (i32.const 4))
-#assertTopStack < i32 > 31 "mul nested in sub folded"
+#assertTopStack < i32 > i2i32(31) "mul nested in sub folded"
 
 #clearConfig

--- a/tests/simple/bitwise.wast
+++ b/tests/simple/bitwise.wast
@@ -1,154 +1,154 @@
 (i32.const 20)
 (i32.const 18)
 (i32.and)
-#assertTopStack < i32 > 16 "and"
+#assertTopStack < i32 > i2i32(16) "and"
 
 (i32.const 20)
 (i32.const 18)
 (i32.or)
-#assertTopStack < i32 > 22 "or"
+#assertTopStack < i32 > i2i32(22) "or"
 
 (i32.const 20)
 (i32.const 18)
 (i32.xor)
-#assertTopStack < i32 > 6 "xor"
+#assertTopStack < i32 > i2i32(6) "xor"
 
 (i32.const 2)
 (i32.const 1)
 (i32.shl)
-#assertTopStack < i32 > 4 "shl 1"
+#assertTopStack < i32 > i2i32(4) "shl 1"
 
 (i32.const 2)
-(i32.add (i32.const #pow1(i32)) (i32.const 1))
+(i32.add (i32.const 2147483648) (i32.const 1))
 (i32.shl)
-#assertTopStack < i32 > 4 "shl 2"
+#assertTopStack < i32 > i2i32(4) "shl 2"
 
-(i32.const #pow1(i32))
+(i32.const 2147483648)
 (i32.const 2)
 (i32.shr_u)
-#assertTopStack < i32 > 536870912 "shr_u 1" ;; 2 ^Int 29
+#assertTopStack < i32 > i2i32(536870912) "shr_u 1" ;; 2 ^Int 29
 
 (i32.const 2)
 (i32.const 2)
 (i32.shr_u)
-#assertTopStack < i32 > 0 "shr_u 2"
+#assertTopStack < i32 > i2i32(0) "shr_u 2"
 
-(i32.sub (i32.const #pow(i32)) (i32.const 2))
+(i32.sub (i32.const 4294967296) (i32.const 2))
 (i32.const 1)
 (i32.shr_s)
-#assertTopStack < i32 > 4294967295 "shr_s 1" ;; #pow(i32) -Int 1
+#assertTopStack < i32 > i2i32(4294967295) "shr_s 1" ;; #pow(i32) -Int 1
 
 (i32.const 2)
 (i32.const 2)
 (i32.shr_s)
-#assertTopStack < i32 > 0 "shr_s 2"
+#assertTopStack < i32 > i2i32(0) "shr_s 2"
 
-(i32.add (i32.const #pow1(i32)) (i32.const 2))
+(i32.add (i32.const 2147483648) (i32.const 2))
 (i32.const 3)
 (i32.rotl)
-#assertTopStack < i32 > 20 "rotl"
+#assertTopStack < i32 > i2i32(20) "rotl"
 
-(i32.add (i32.const #pow1(i32)) (i32.const 16))
+(i32.add (i32.const 2147483648) (i32.const 16))
 (i32.const 3)
 (i32.rotr)
-#assertTopStack < i32 > 268435458 "rotr" ;; 2 ^Int 28 +Int 2
+#assertTopStack < i32 > i2i32(268435458) "rotr" ;; 2 ^Int 28 +Int 2
 
 ;; clz
 
-(i32.const #pow1(i32))
+(i32.const 2147483648)
 (i32.clz)
-#assertTopStack < i32 > 0 "clz #pow1(i32)"
-(i64.const #pow1(i64))
+#assertTopStack < i32 > i2i32(0) "clz #pow1(i32)"
+(i64.const 9223372036854775808)
 (i64.clz)
-#assertTopStack < i64 > 0 "clz #pow1(i62)"
+#assertTopStack < i64 > i2i64(0) "clz #pow1(i62)"
 
 (i32.const 0)
 (i32.clz)
-#assertTopStack < i32 > 32 "clz 0"
+#assertTopStack < i32 > i2i32(32) "clz 0"
 (i64.const 0)
 (i64.clz)
-#assertTopStack < i64 > 64 "clz 0"
+#assertTopStack < i64 > i2i64(64) "clz 0"
 
 (i32.const 1)
 (i32.clz)
-#assertTopStack < i32 > 31 "clz 1"
+#assertTopStack < i32 > i2i32(31) "clz 1"
 (i64.const 1)
 (i64.clz)
-#assertTopStack < i64 > 63 "clz 1"
+#assertTopStack < i64 > i2i64(63) "clz 1"
 
-(i32.sub (i32.const #pow(i32)) (i32.const 1))
+(i32.sub (i32.const 4294967296) (i32.const 1))
 (i32.clz)
-#assertTopStack < i32 > 0 "clz 2^32 - 1"
+#assertTopStack < i32 > i2i32(0) "clz 2^32 - 1"
 
-(i64.sub (i64.const #pow(i64)) (i64.const 1))
+(i64.sub (i64.const 18446744073709551616) (i64.const 1))
 (i64.clz)
-#assertTopStack < i64 > 0 "clz 2^64 - 1"
+#assertTopStack < i64 > i2i64(0) "clz 2^64 - 1"
 
-(i32.sub (i32.const #pow1(i32)) (i32.const 1))
+(i32.sub (i32.const 2147483648) (i32.const 1))
 (i32.clz)
-#assertTopStack < i32 > 1 "clz 2^31 - 1"
+#assertTopStack < i32 > i2i32(1) "clz 2^31 - 1"
 
-(i64.sub (i64.const #pow1(i64)) (i64.const 1))
+(i64.sub (i64.const 9223372036854775808) (i64.const 1))
 (i64.clz)
-#assertTopStack < i64 > 1 "clz 2^63 - 1"
+#assertTopStack < i64 > i2i64(1) "clz 2^63 - 1"
 
 ;; ctz
-(i32.const #pow1(i32))
+(i32.const 2147483648)
 (i32.ctz)
-#assertTopStack < i32 > 31 "ctz #pow1(i32)"
-(i64.const #pow1(i64))
+#assertTopStack < i32 > i2i32(31) "ctz #pow1(i32)"
+(i64.const 9223372036854775808)
 (i64.ctz)
-#assertTopStack < i64 > 63 "ctz #pow1(i32)"
+#assertTopStack < i64 > i2i64(63) "ctz #pow1(i32)"
 
 (i32.const 0)
 (i32.ctz)
-#assertTopStack < i32 > 32 "ctz 0"
+#assertTopStack < i32 > i2i32(32) "ctz 0"
 (i64.const 0)
 (i64.ctz)
-#assertTopStack < i64 > 64 "ctz 0"
+#assertTopStack < i64 > i2i64(64) "ctz 0"
 
 (i32.const 1)
 (i32.ctz)
-#assertTopStack < i32 > 0 "ctz 1"
+#assertTopStack < i32 > i2i32(0) "ctz 1"
 (i64.const 1)
 (i64.ctz)
-#assertTopStack < i64 > 0 "ctz 1"
+#assertTopStack < i64 > i2i64(0) "ctz 1"
 
-(i32.sub (i32.const #pow(i32)) (i32.const 1))
+(i32.sub (i32.const 4294967296) (i32.const 1))
 (i32.ctz)
-#assertTopStack < i32 > 0 "ctz 2^32 - 1"
-(i64.sub (i64.const #pow(i64)) (i64.const 1))
+#assertTopStack < i32 > i2i32(0) "ctz 2^32 - 1"
+(i64.sub (i64.const 18446744073709551616) (i64.const 1))
 (i64.ctz)
-#assertTopStack < i64 > 0 "ctz 2^64 - 1"
+#assertTopStack < i64 > i2i64(0) "ctz 2^64 - 1"
 
 ;; popcnt
 
-(i32.const #pow1(i32))
+(i32.const 2147483648)
 (i32.popcnt)
-#assertTopStack < i32 > 1 "popcnt #pow1(i32)"
-(i64.const #pow1(i64))
+#assertTopStack < i32 > i2i32(1) "popcnt #pow1(i32)"
+(i64.const 9223372036854775808)
 (i64.popcnt)
-#assertTopStack < i64 > 1 "popcnt #pow1(i32)"
+#assertTopStack < i64 > i2i64(1) "popcnt #pow1(i32)"
 
 (i32.const 0)
 (i32.popcnt)
-#assertTopStack < i32 > 0 "popcnt 0"
+#assertTopStack < i32 > i2i32(0) "popcnt 0"
 (i64.const 0)
 (i64.popcnt)
-#assertTopStack < i64 > 0 "popcnt 0"
+#assertTopStack < i64 > i2i64(0) "popcnt 0"
 
 (i32.const 1)
 (i32.popcnt)
-#assertTopStack < i32 > 1 "popcnt 1"
+#assertTopStack < i32 > i2i32(1) "popcnt 1"
 (i64.const 1)
 (i64.popcnt)
-#assertTopStack < i64 > 1 "popcnt 1"
+#assertTopStack < i64 > i2i64(1) "popcnt 1"
 
-(i32.sub (i32.const #pow(i32)) (i32.const 1))
+(i32.sub (i32.const 4294967296) (i32.const 1))
 (i32.popcnt)
-#assertTopStack < i32 > 32 "popcnt 2^32 - 1"
-(i64.sub (i64.const #pow(i64)) (i64.const 1))
+#assertTopStack < i32 > i2i32(32) "popcnt 2^32 - 1"
+(i64.sub (i64.const 18446744073709551616) (i64.const 1))
 (i64.popcnt)
-#assertTopStack < i64 > 64 "popcnt 2^64 - 1"
+#assertTopStack < i64 > i2i64(64) "popcnt 2^64 - 1"
 
 #clearConfig

--- a/tests/simple/comments.wast
+++ b/tests/simple/comments.wast
@@ -8,16 +8,16 @@ all this text
 should be ignored
 ;)
 
-#assertTopStack < i32 > 15 "dummy test 1"
+#assertTopStack < i32 > i2i32(15) "dummy test 1"
 
 (i32.const -3)
 (i32.const 6)     (; comment at end of line ;)
 (i32.add)
-#assertTopStack < i32 > 3 "dummy test 2"
+#assertTopStack < i32 > i2i32(3) "dummy test 2"
 
 (i32.const -3)
 (i32.(;comment in the middle;)const 6)
 (i32.add)
-#assertTopStack < i32 > 3 "dummy test 2"
+#assertTopStack < i32 > i2i32(3) "dummy test 2"
 
 #clearConfig

--- a/tests/simple/comparison.wast
+++ b/tests/simple/comparison.wast
@@ -1,115 +1,115 @@
 (i32.const 0)
 (i32.eqz)
-#assertTopStack < i32 > 1 "eqz1"
+#assertTopStack < i32 > i2i32(1) "eqz1"
 
 (i32.const 3)
 (i32.eqz)
-#assertTopStack < i32 > 0 "eqz2"
+#assertTopStack < i32 > i2i32(0) "eqz2"
 
 (i32.eqz (i32.const 3))
-#assertTopStack < i32 > 0 "eqz folded"
+#assertTopStack < i32 > i2i32(0) "eqz folded"
 
 (i32.const 3)
 (i32.const 3)
 (i32.eq)
-#assertTopStack < i32 > 1 "eq1"
+#assertTopStack < i32 > i2i32(1) "eq1"
 
 (i32.const 3)
 (i32.const 4)
 (i32.eq)
-#assertTopStack < i32 > 0 "eq2"
+#assertTopStack < i32 > i2i32(0) "eq2"
 
 (i32.const 3)
 (i32.const 3)
 (i32.ne)
-#assertTopStack < i32 > 0 "ne1"
+#assertTopStack < i32 > i2i32(0) "ne1"
 
 (i32.const 3)
 (i32.const 4)
 (i32.ne)
-#assertTopStack < i32 > 1 "ne2"
+#assertTopStack < i32 > i2i32(1) "ne2"
 
 (i32.const 2)
 (i32.const 32)
 (i32.lt_u)
-#assertTopStack < i32 > 1 "lt_u"
+#assertTopStack < i32 > i2i32(1) "lt_u"
 
 (i32.lt_u (i32.const 32) (i32.const 2))
-#assertTopStack < i32 > 0 "lt_u"
+#assertTopStack < i32 > i2i32(0) "lt_u"
 
 (i32.const 2)
 (i32.const 32)
 (i32.gt_u)
-#assertTopStack < i32 > 0 "gt_u"
+#assertTopStack < i32 > i2i32(0) "gt_u"
 
-(i32.add (i32.const #pow1(i32)) (i32.const 7))
-(i32.add (i32.const #pow1(i32)) (i32.const 15))
+(i32.add (i32.const 2147483648) (i32.const 7))
+(i32.add (i32.const 2147483648) (i32.const 15))
 (i32.lt_s)
-#assertTopStack < i32 > 1 "lt_s 1"
+#assertTopStack < i32 > i2i32(1) "lt_s 1"
 
 (i32.const -32)
 (i32.const 32)
 (i32.lt_s)
-#assertTopStack < i32 > 1 "lt_s 2"
+#assertTopStack < i32 > i2i32(1) "lt_s 2"
 
-(i32.add (i32.const #pow1(i32)) (i32.const 7))
-(i32.add (i32.const #pow1(i32)) (i32.const 15))
+(i32.add (i32.const 2147483648) (i32.const 7))
+(i32.add (i32.const 2147483648) (i32.const 15))
 (i32.gt_s)
-#assertTopStack < i32 > 0 "gt_s 1"
+#assertTopStack < i32 > i2i32(0) "gt_s 1"
 
 (i32.const -32)
 (i32.const 32)
 (i32.gt_s)
-#assertTopStack < i32 > 0 "gt_s 2"
+#assertTopStack < i32 > i2i32(0) "gt_s 2"
 
 (i32.const 2)
 (i32.const 32)
 (i32.le_u)
-#assertTopStack < i32 > 1 "le_u 1"
+#assertTopStack < i32 > i2i32(1) "le_u 1"
 
 (i32.const 32)
 (i32.const 32)
 (i32.le_u)
-#assertTopStack < i32 > 1 "le_u 2"
+#assertTopStack < i32 > i2i32(1) "le_u 2"
 
 (i32.const 2)
 (i32.const 32)
 (i32.ge_u)
-#assertTopStack < i32 > 0 "ge_u 1"
+#assertTopStack < i32 > i2i32(0) "ge_u 1"
 
 (i32.const 32)
 (i32.const 32)
 (i32.ge_u)
-#assertTopStack < i32 > 1 "ge_u 2"
+#assertTopStack < i32 > i2i32(1) "ge_u 2"
 
-(i32.add (i32.const #pow1(i32)) (i32.const 7))
-(i32.add (i32.const #pow1(i32)) (i32.const 15))
+(i32.add (i32.const 2147483648) (i32.const 7))
+(i32.add (i32.const 2147483648) (i32.const 15))
 (i32.le_s)
-#assertTopStack < i32 > 1 "le_s 1"
+#assertTopStack < i32 > i2i32(1) "le_s 1"
 
 (i32.const 32)
 (i32.const 32)
 (i32.le_s)
-#assertTopStack < i32 > 1 "le_s 2"
+#assertTopStack < i32 > i2i32(1) "le_s 2"
 
 (i32.const -32)
 (i32.const 32)
 (i32.le_s)
-#assertTopStack < i32 > 1 "le_s 3"
+#assertTopStack < i32 > i2i32(1) "le_s 3"
 
-(i32.add (i32.const #pow1(i32)) (i32.const 7))
-(i32.add (i32.const #pow1(i32)) (i32.const 15))
+(i32.add (i32.const 2147483648) (i32.const 7))
+(i32.add (i32.const 2147483648) (i32.const 15))
 (i32.ge_s)
-#assertTopStack < i32 > 0 "ge_s 1"
+#assertTopStack < i32 > i2i32(0) "ge_s 1"
 
 (i32.const 32)
 (i32.const 32)
 (i32.ge_s)
-#assertTopStack < i32 > 1 "ge_s 2"
+#assertTopStack < i32 > i2i32(1) "ge_s 2"
 
 (i32.const -32)
 (i32.const 32)
 (i32.ge_s)
-#assertTopStack < i32 > 0 "ge_s 3"
+#assertTopStack < i32 > i2i32(0) "ge_s 3"
 
 #clearConfig

--- a/tests/simple/constants.wast
+++ b/tests/simple/constants.wast
@@ -2,34 +2,34 @@
 ;; --------
 
 (i32.const 3)
-#assertTopStack < i32 > 3 "i32 1"
+#assertTopStack < i32 > i2i32(3) "i32 1"
 
 (i32.const 5)
-#assertTopStack < i32 > 5 "i32 parens"
+#assertTopStack < i32 > i2i32(5) "i32 parens"
 
 (i64.const 71)
-#assertTopStack < i64 > 71 "i64"
-
-(i32.const #unsigned(i32, -5))
-#assertTopStack < i32 > 4294967291 "i32 manual unsigned" ;; #pow(i32) -Int 5
-
-(i32.sub (i32.const #pow(i32)) (i32.const 5))
-#assertTopStack < i32 > -5 "i32 manual unsigned"
+#assertTopStack < i64 > i2i64(71) "i64"
 
 (i32.const -5)
-#assertTopStack < i32 > #unsigned(i32, -5) "i32 signed constant"
+#assertTopStack < i32 > i2i32(4294967291) "i32 manual unsigned" ;; #pow(i32) -Int 5
 
-(i32.const #unsigned(i32, -5))
-#assertTopStack < i32 > -5 "i32 signed assert"
+(i32.sub (i32.const 4294967296) (i32.const 5))
+#assertTopStack < i32 > i2i32(-5) "i32 manual unsigned"
 
-(i32.add (i32.const #pow(i32)) (i32.const 1))
-#assertTopStack < i32 > 1 "i32 overflow"
+(i32.const -5)
+#assertTopStack < i32 > i2i32(-5) "i32 signed constant"
+
+(i32.const 4294967291)
+#assertTopStack < i32 > i2i32(-5) "i32 signed assert"
+
+(i32.add (i32.const 4294967296) (i32.const 1))
+#assertTopStack < i32 > i2i32(1) "i32 overflow"
 
 (i32.const -1)
-#assertTopStackExactly < i32 > 4294967295 "i32 overflow"
+#assertTopStackExactly < i32 > i2i32(4294967295) "i32 overflow"
 
 (i64.const -1)
-#assertTopStackExactly < i64 > 18446744073709551615 "i62 overflow" ;; #pow(i64) -Int 1
+#assertTopStackExactly < i64 > i2i64(18446744073709551615) "i62 overflow" ;; #pow(i64) -Int 1
 
 ;; Floating point
 ;; --------------
@@ -57,16 +57,16 @@
 ;; Helper conversions
 ;; ------------------
 
-(i32.const #unsigned(i32, #signed(i32, 0)))
-#assertTopStack < i32 > 0 "#unsigned . #signed 1"
+(i32.const 0)
+#assertTopStack < i32 > i2i32(0) "#unsigned . #signed 1"
 
-(i32.const #unsigned(i32, #signed(i32, #pow1(i32))))
-#assertTopStack < i32 > #pow1(i32) "#unsigned . #signed 2"
+(i32.const 2147483648)
+#assertTopStack < i32 > i2i32(-2147483648) "#unsigned . #signed 2"
 
-(i64.const #unsigned(i64, #signed(i64, 0)))
-#assertTopStack < i64 > 0 "#unsigned . #signed 4"
+(i64.const 0)
+#assertTopStack < i64 > i2i64(0) "#unsigned . #signed 4"
 
-(i64.const #unsigned(i64, #signed(i64, #pow1(i64))))
-#assertTopStack < i64 > #pow1(i64) "#unsigned . #signed 5"
+(i64.const 9223372036854775808)
+#assertTopStack < i64 > i2i64(-9223372036854775808) "#unsigned . #signed 5"
 
 #clearConfig

--- a/tests/simple/control-flow.wast
+++ b/tests/simple/control-flow.wast
@@ -9,7 +9,7 @@ block (result i32 i32 i32)
     (i32.const 2)
     (i32.const 3)
 end
-#assertStack < i32 > 3 : < i32 > 2 : < i32 > 1 : .ValStack "block 1"
+#assertStack < i32 > i2i32(3) : < i32 > i2i32(2) : < i32 > i2i32(1) : .ValStack "block 1"
 
 block (result i32 i32)
     (i32.const 1)
@@ -17,26 +17,26 @@ block (result i32 i32)
     (i32.const 3)
     (drop)
 end
-#assertStack < i32 > 2 : < i32 > 1 : .ValStack "block 2"
+#assertStack < i32 > i2i32(2) : < i32 > i2i32(1) : .ValStack "block 2"
 
 block (result i32 i32)
     (i32.const 1)
     (i32.const 2)
     (i32.const 3)
 end
-#assertStack < i32 > 3 : < i32 > 2 : .ValStack "block 3 (invalid)"
+#assertStack < i32 > i2i32(3) : < i32 > i2i32(2) : .ValStack "block 3 (invalid)"
 
 ;; (block (result i32)
 ;;     (i32.const 1)
 ;; )
-;; #assertTopStack < i32 > 1 "block with named result 1"
+;; #assertTopStack < i32 > i2i32(1) "block with named result 1"
 
 ;; (block result i64 i32
 ;;     (i32.const 2)
 ;;     (i32.const 1)
 ;;     (i64.const 5)
 ;; )
-;; #assertStack < i64 > 5 : < i32 > 1 : .ValStack "block with named result 2"
+;; #assertStack < i64 > 5 : < i32 > i2i32(1) : .ValStack "block with named result 2"
 
 ;; Breaks
 
@@ -48,7 +48,7 @@ block
     (i32.const 4)
     (br 0)
 end
-#assertStack < i32 > 2 : < i32 > 1 : .ValStack "br 1"
+#assertStack < i32 > i2i32(2) : < i32 > i2i32(1) : .ValStack "br 1"
 
 (i32.const 1)
 (i32.const 2)
@@ -62,7 +62,7 @@ block
     (i32.const 6)
     (br 0)
 end
-#assertStack < i32 > 2 : < i32 > 1 : .ValStack "br 2"
+#assertStack < i32 > i2i32(2) : < i32 > i2i32(1) : .ValStack "br 2"
 
 (i32.const 1)
 (i32.const 2)
@@ -76,7 +76,7 @@ block (result i32 i32)
     (i32.const 6)
     (br 0)
 end
-#assertStack < i32 > 5 : < i32 > 4 : < i32 > 2 : < i32 > 1 : .ValStack "br 3"
+#assertStack < i32 > i2i32(5) : < i32 > i2i32(4) : < i32 > i2i32(2) : < i32 > i2i32(1) : .ValStack "br 3"
 
 (i32.const 1)
 (i32.const 2)
@@ -90,7 +90,7 @@ block (result i32 i32)
     (i32.const 6)
     (br 0)
 end
-#assertStack < i32 > 5 : < i32 > 4 : < i32 > 2 : < i32 > 1 : .ValStack "br 4"
+#assertStack < i32 > i2i32(5) : < i32 > i2i32(4) : < i32 > i2i32(2) : < i32 > i2i32(1) : .ValStack "br 4"
 
 (i32.const 1)
 (i32.const 2)
@@ -101,7 +101,7 @@ block (result i32)
     (i32.const 4)
     (br 0)
 end
-#assertStack < i32 > 4 : < i32 > 2 : < i32 > 1 : .ValStack "br_if 1 false"
+#assertStack < i32 > i2i32(4) : < i32 > i2i32(2) : < i32 > i2i32(1) : .ValStack "br_if 1 false"
 
 (i32.const 1)
 (i32.const 2)
@@ -112,7 +112,7 @@ block (result i32)
     (i32.const 4)
     (br 0)
 end
-#assertStack < i32 > 3 : < i32 > 2 : < i32 > 1 : .ValStack "br_if 1 true"
+#assertStack < i32 > i2i32(3) : < i32 > i2i32(2) : < i32 > i2i32(1) : .ValStack "br_if 1 true"
 
 (i32.const 1)
 (i32.const 2)
@@ -123,38 +123,38 @@ block
     (i32.const 4)
     (br 0)
 end
-#assertStack < i32 > 2 : < i32 > 1 : .ValStack "br_if 2 true"
+#assertStack < i32 > i2i32(2) : < i32 > i2i32(1) : .ValStack "br_if 2 true"
 
 ;; Conditional
 
 (i32.const 1)
 if (result i32) i32.const 1 else i32.const -1 end
-#assertTopStack < i32 > 1 "if true"
+#assertTopStack < i32 > i2i32(1) "if true"
 
 (i32.const 0)
 if (result i32) i32.const 1 else i32.const -1 end
-#assertTopStack < i32 > -1 "if false"
+#assertTopStack < i32 > i2i32(-1) "if false"
 
 ;; (i32.const -1)
 ;; (if (i32.const 0) (then))
-;; #assertTopStack < i32 > -1 "if folded false empty"
+;; #assertTopStack < i32 > i2i32(-1) "if folded false empty"
 
 ;; (i32.const -1)
 ;; (if (result i32) (i32.const 1) (then (i32.const 1)) (else (i32.const 2)))
-;; #assertStack < i32 > 1 : < i32 > -1 : .ValStack "if folded true"
+;; #assertStack < i32 > i2i32(1) : < i32 > i2i32(-1) : .ValStack "if folded true"
 
 ;; (i32.const -1)
 ;; (if (result i32) (i32.const 0) (then (i32.const 1)) (else (i32.const 2)))
-;; #assertStack < i32 > 2 : < i32 > -1 : .ValStack "if folded false"
+;; #assertStack < i32 > i2i32(2) : < i32 > i2i32(-1) : .ValStack "if folded false"
 
 ;; (if (result i32) (i32.const 1) (then (unreachable)) (else (i32.const 1)))
 ;; #assertTrap "if lazy first branch true"
 
 ;; (if (result i32) (i32.const 0) (then (unreachable)) (else (i32.const 1)))
-;; #assertTopStack < i32 > 1 "if lazy first branch false"
+;; #assertTopStack < i32 > i2i32(1) "if lazy first branch false"
 
 ;; (if (result i32) (i32.const 1) (then (i32.const -1)) (else (unreachable)))
-;; #assertTopStack < i32 > -1 "if lazy second branch true"
+;; #assertTopStack < i32 > i2i32(-1) "if lazy second branch true"
 
 ;; (if (result i32) (i32.const 0) (then (i32.const -1)) (else (unreachable)))
 ;; #assertTrap "if lazy second branch false"
@@ -164,7 +164,7 @@ if (result i32) i32.const 1 else i32.const -1 end
 
 ;; Looping
 
-init_locals < i32 > 10 : < i32 > 0 : .ValStack
+init_locals < i32 > i2i32(10) : < i32 > i2i32(0) : .ValStack
 loop
     (local.get 0)
     (local.get 1)
@@ -176,10 +176,10 @@ loop
     (local.tee 0)
     (br_if 0)
 end
-#assertLocal 0 < i32 > 0  "sum 1 -> 10 loop"
-#assertLocal 1 < i32 > 55 "sum 1 -> 10 loop"
+#assertLocal 0 < i32 > i2i32(0)  "sum 1 -> 10 loop"
+#assertLocal 1 < i32 > i2i32(55) "sum 1 -> 10 loop"
 
-init_locals < i32 > 10 : < i32 > 0 : .ValStack
+init_locals < i32 > i2i32(10) : < i32 > i2i32(0) : .ValStack
 block
     loop
         (local.get 0)
@@ -195,8 +195,8 @@ block
         (br 0)
     end
 end
-#assertLocal 0 < i32 > 0  "sum 1 -> 10 loop concrete syntax"
-#assertLocal 1 < i32 > 55 "sum 1 -> 10 loop concrete syntax"
+#assertLocal 0 < i32 > i2i32(0)  "sum 1 -> 10 loop concrete syntax"
+#assertLocal 1 < i32 > i2i32(55) "sum 1 -> 10 loop concrete syntax"
 
 ;; Stack Underflow
 ;; TODO: We need to give semantics to stack underflow (though it could not happen with a validated program).

--- a/tests/simple/conversion.wast
+++ b/tests/simple/conversion.wast
@@ -2,27 +2,27 @@
 
 (i64.const 4294967296)    ;; 2^32
 (i32.wrap_i64)
-#assertTopStack < i32 > 0 "wrap 2^32"
+#assertTopStack < i32 > i2i32(0) "wrap 2^32"
 
 (i64.const 4294967295)    ;; 2^32 - 1
 (i32.wrap_i64)
-#assertTopStack < i32 > 4294967295 "wrap 2^32 - 1"
+#assertTopStack < i32 > i2i32(4294967295) "wrap 2^32 - 1"
 
 (i32.wrap_i64 (i64.const 4294967298))
-#assertTopStack < i32 > 2 "folded wrap 2^32 + 2"
+#assertTopStack < i32 > i2i32(2) "folded wrap 2^32 + 2"
 
 ;; Extend.
 
 (i32.const 4294967295)    ;; 2^32 - 1
 (i64.extend_i32_u)
-#assertTopStack < i64 > 4294967295 "extend unsig"
+#assertTopStack < i64 > i2i64(4294967295) "extend unsig"
 
 (i32.const -1)    ;; 2^32 - 1
 (i64.extend_i32_s)
-#assertTopStack < i64 > -1 "extend sig"
+#assertTopStack < i64 > i2i64(-1) "extend sig"
 
 (i64.extend_i32_s (i32.const 15))
-#assertTopStack < i64 > 15 "folded extend sig"
+#assertTopStack < i64 > i2i64(15) "folded extend sig"
 
 (module
   (func (export "i64.extend_i32_s") (param $x i32) (result i64) (i64.extend_i32_s (local.get $x)))

--- a/tests/simple/data.wast
+++ b/tests/simple/data.wast
@@ -6,7 +6,7 @@
 
 (memory.size)
 
-#assertTopStack < i32 > 1 "size of stack"
+#assertTopStack < i32 > i2i32(1) "size of stack"
 #assertMemoryData (0, 87) "text to ascii W"
 #assertMemoryData (1, 65) "text to ascii A"
 #assertMemoryData (2, 83) "text to ascii S"

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -65,7 +65,7 @@
 (i32.const 0)
 (call_indirect (type $a-cool-type))
 
-#assertTopStack < i32 > 15 "call function 0 no return"
+#assertTopStack < i32 > i2i32(15) "call function 0 no return"
 (drop)
 #assertFunction 2 [ i32 i32 ] -> [ i32 ] [ ] "call function 0 exists no return"
 

--- a/tests/simple/memory.wast
+++ b/tests/simple/memory.wast
@@ -20,7 +20,7 @@
 
 ( memory $mem 0 10 )
 (memory.size)
-#assertTopStack <i32> 0 "memory.size 1"
+#assertTopStack < i32 > i2i32(0) "memory.size 1"
 #assertMemory $mem 0 10 "memory ungrown"
 
 #clearConfig
@@ -28,28 +28,28 @@
 ( memory $mem 0 10 )
 (memory.grow (i32.const 10))
 (memory.size)
-#assertStack <i32> 10 : < i32 > 0 : .ValStack "memory grow"
+#assertStack < i32 > i2i32(10) : < i32 > i2i32(0) : .ValStack "memory grow"
 (memory.grow (i32.const 1))
-#assertTopStack <i32> -1 "memory grow"
+#assertTopStack < i32 > i2i32(-1) "memory grow"
 #assertMemory $mem 10 10 "memory grown"
 
 #clearConfig
 
-( memory #maxMemorySize())
+( memory 65536)
 (memory.grow (i32.const 1))
-#assertTopStack <i32> -1 "memory grow max too large"
-#assertMemory 0 #maxMemorySize() .Int "memory grow max too large"
+#assertTopStack < i32 > i2i32(-1) "memory grow max too large"
+#assertMemory 0 65536 .Int "memory grow max too large"
 
 #clearConfig
 
 ( memory 0 )
-(memory.grow (i32.const #maxMemorySize()))
+(memory.grow (i32.const 65536))
 (memory.size)
-#assertStack <i32> #maxMemorySize() : < i32 > 0 : .ValStack "memory grow unbounded"
+#assertStack < i32 > i2i32(65536) : < i32 > i2i32(0) : .ValStack "memory grow unbounded"
 (memory.grow (i32.const 1))
 (memory.size)
-#assertStack <i32> #maxMemorySize() : < i32 > -1 : .ValStack "memory grow unbounded"
-#assertMemory 0 #maxMemorySize() .Int "memory grown unbounded"
+#assertStack < i32 > i2i32(65536) : < i32 > i2i32(-1) : .ValStack "memory grow unbounded"
+#assertMemory 0 65536 .Int "memory grown unbounded"
 
 ;; Store and load
 
@@ -69,7 +69,7 @@
 (i64.store16 offset=2)
 #assertMemoryData (3, 1) "store16"
 (i32.const 1)
-(i64.add (i64.const #pow(i32)) (i64.const 1))
+(i64.add (i64.const 4294967296) (i64.const 1))
 (i64.store16 offset=2)
 #assertMemoryData (3, 1) "store32"
 #assertMemory 0 1 .Int ""
@@ -100,32 +100,32 @@
 
 (memory 1)
 (i32.const 15)
-(i64.sub (i64.const #pow(i32)) (i64.const 1))
+(i64.sub (i64.const 4294967296) (i64.const 1))
 (i64.store)
 (i32.const 15)
 (i32.load8_u)
-#assertTopStack <i32> 255 "load8 unsigned"
+#assertTopStack < i32 > i2i32(255) "load8 unsigned"
 (i32.const 15)
 (i32.load8_s )
-#assertTopStack <i32> -1 "load8 signed"
+#assertTopStack < i32 > i2i32(-1) "load8 signed"
 (i32.const 16)
 (i32.load16_u )
-#assertTopStack <i32> 65535 "load16 unsigned"
+#assertTopStack < i32 > i2i32(65535) "load16 unsigned"
 (i32.const 16)
 (i32.load16_s )
-#assertTopStack <i32> -1 "load16 signed"
+#assertTopStack < i32 > i2i32(-1) "load16 signed"
 (i32.const 15)
 (i64.load32_u )
-#assertTopStack <i64> 4294967295 "load32 unsigned1" ;; #pow(i32) -Int 1
+#assertTopStack < i64 > i2i64(4294967295) "load32 unsigned1" ;; #pow(i32) -Int 1
 (i32.const 15)
 (i64.load32_s )
-#assertTopStack <i64> -1 "load32 signed1"
+#assertTopStack < i64 > i2i64(-1) "load32 signed1"
 (i32.const 17)
 (i64.load32_u )
-#assertTopStack <i64> 65535 "load32 unsigned2"
+#assertTopStack < i64 > i2i64(65535) "load32 unsigned2"
 (i32.const 17)
 (i64.load32_u )
-#assertTopStack <i64> 65535 "load32 signed2"
+#assertTopStack < i64 > i2i64(65535) "load32 signed2"
 #assertMemoryData (15, 255) ""
 #assertMemoryData (16, 255) ""
 #assertMemoryData (17, 255) ""
@@ -138,7 +138,7 @@
 
 (memory 1)
 (i32.const 1)
-(i64.sub (i64.const #pow(i64)) (i64.const 1))
+(i64.sub (i64.const 18446744073709551616) (i64.const 1))
 (i64.store)
 (i32.const 5) (i32.const 0)
 (i32.store   )
@@ -153,7 +153,7 @@
 #clearConfig
 
 (memory 1)
-(i32.const 1) (i64.sub (i64.const #pow(i64)) (i64.const 1))
+(i32.const 1) (i64.sub (i64.const 18446744073709551616) (i64.const 1))
 (i64.store )
 (i32.const 2) (i32.const 0)
 (i32.store8 )

--- a/tests/simple/polymorphic.wast
+++ b/tests/simple/polymorphic.wast
@@ -18,7 +18,7 @@
 
 (i32.const 5)
 (drop (i32.const 1))
-#assertTopStack < i32 > 5 "folded drop"
+#assertTopStack < i32 > i2i32(5) "folded drop"
 
 ;; select
 
@@ -26,43 +26,43 @@
 (i32.const 1)
 (i32.const 1)
 (select)
-#assertTopStack < i32 > -1 "select i32 true"
+#assertTopStack < i32 > i2i32(-1) "select i32 true"
 
 (i32.const -1)
 (i32.const 1)
 (i32.const 0)
 (select)
-#assertTopStack < i32 > 1 "select i32 false"
+#assertTopStack < i32 > i2i32(1) "select i32 false"
 
 (i64.const -1)
 (i64.const 1)
 (i32.const 1)
 (select)
-#assertTopStack < i64 > -1 "select i64 true"
+#assertTopStack < i64 > i2i64(-1) "select i64 true"
 
 (i64.const -1)
 (i64.const 1)
 (i32.const 0)
 (select)
-#assertTopStack < i64 > 1 "select i64 false"
+#assertTopStack < i64 > i2i64(1) "select i64 false"
 
 (select (i32.const 1) (i32.const 0) (i32.const 1))
-#assertTopStack < i32 > 1 "folded select i32"
+#assertTopStack < i32 > i2i32(1) "folded select i32"
 
 (select (i64.const 1) (i64.const 0) (i32.const 0))
-#assertTopStack < i64 > 0 "folded select i64"
+#assertTopStack < i64 > i2i64(0) "folded select i64"
 
 (select (unreachable) (i64.const -1) (i32.const 0))
 #assertTrap                "select strict in first branch"
 
 (select (i64.const 1) (unreachable) (i32.const 0))
 #assertTrap               "select strict in second branch"
-#assertTopStack < i64 > 1 "select strict in second branch"
+#assertTopStack < i64 > i2i64(1) "select strict in second branch"
 
 (select (i64.const 1) (i64.const -1) (unreachable))
 #assertTrap                "select strict in condition"
-#assertTopStack < i64 > -1 "select strict in condition"
+#assertTopStack < i64 > i2i64(-1) "select strict in condition"
 (drop)
-#assertTopStack < i64 >  1 "select strict in condition"
+#assertTopStack < i64 > i2i64(1) "select strict in condition"
 
 #clearConfig

--- a/tests/simple/table.wast
+++ b/tests/simple/table.wast
@@ -56,11 +56,11 @@
 
 (invoke "call-8")
 
-#assertTopStack < i32> 65 "call_indirect_result1"
+#assertTopStack < i32 > i2i32(65) "call_indirect_result1"
 
 (invoke "call-9")
 
-#assertTopStack < i32> 66 "call_indirect_result2"
+#assertTopStack < i32 > i2i32(66) "call_indirect_result2"
 
 #assertFunction 0 [ ] -> [ i32 ] [ ] "call function 1 exists"
 #assertFunction 1 [ ] -> [ i32 ] [ ] "call function 2 exists"

--- a/tests/simple/variables.wast
+++ b/tests/simple/variables.wast
@@ -1,21 +1,21 @@
 ;; Test locals
 
-init_locals < i32 > 0 : < i32 > 0 : < i32 > 0 : .ValStack
+init_locals < i32 > i2i32(0) : < i32 > i2i32(0) : < i32 > i2i32(0) : .ValStack
 
 (i32.const 43)
 (local.set 0)
-#assertLocal 0 < i32 > 43 "set_local"
+#assertLocal 0 < i32 > i2i32(43) "set_local"
 
 (i32.const 55)
 (local.set 1)
 (local.get 1)
-#assertTopStack < i32 > 55 "set_local stack"
-#assertLocal 1 < i32 > 55 "set_local"
+#assertTopStack < i32 > i2i32(55) "set_local stack"
+#assertLocal 1 < i32 > i2i32(55) "set_local"
 
 (i32.const 67)
 (local.tee 2)
-#assertTopStack < i32 > 67 "tee_local stack"
-#assertLocal 2 < i32 > 67 "tee_local local"
+#assertTopStack < i32 > i2i32(67) "tee_local stack"
+#assertLocal 2 < i32 > i2i32(67) "tee_local local"
 
 ;; Test globals
 
@@ -35,10 +35,10 @@ init_locals < i32 > 0 : < i32 > 0 : < i32 > 0 : .ValStack
 
     (start 0)
 )
-#assertGlobal 0 < i32 > 43 "set_global"
+#assertGlobal 0 < i32 > i2i32(43) "set_global"
 
 (invoke "set")
-#assertGlobal $someglobal < i32 > 55 "set_global"
+#assertGlobal $someglobal < i32 > i2i32(55) "set_global"
 
 ;; Test global folded forms
 
@@ -56,7 +56,7 @@ init_locals < i32 > 0 : < i32 > 0 : < i32 > 0 : .ValStack
     (start 0)
 )
 
-#assertGlobal 1 < i32 > 99 "set_global folded"
-#assertGlobal 0 < i32 > 77 "set_global folded 2"
+#assertGlobal 1 < i32 > i2i32(99) "set_global folded"
+#assertGlobal 0 < i32 > i2i32(77) "set_global folded 2"
 
 #clearConfig


### PR DESCRIPTION
A lot of time was being spent in GMP even though we are primarily using 32-bit and 64-bit native arithmetic. We save a lot of time by doing this using the MInt sort which compiles down directly to the i32 and i64 types in LLVM.