### PR TITLE
add missing attributes to List modules

### DIFF
--- a/pykwasm/src/pykwasm/kdist/wasm-semantics/data/list-int.k
+++ b/pykwasm/src/pykwasm/kdist/wasm-semantics/data/list-int.k
@@ -12,7 +12,7 @@ module LIST-INT
           [ left, function, total, hook(LIST.concat),
             symbol(_ListInt_), smtlib(smt_seq_concat),
             assoc, unit(.ListInt), element(ListIntItem),
-            format(%1%n%2)
+            format(%1%n%2), update(ListInt:set)
           ]
   syntax ListInt ::= ".ListInt"
           [ function, total, hook(LIST.unit), symbol(.ListInt),

--- a/pykwasm/src/pykwasm/kdist/wasm-semantics/data/list-ref.k
+++ b/pykwasm/src/pykwasm/kdist/wasm-semantics/data/list-ref.k
@@ -12,7 +12,7 @@ module LIST-REF
           [ left, function, total, hook(LIST.concat),
             symbol(_ListRef_), smtlib(smt_seq_concat),
             assoc, unit(.ListRef), element(ListRefItem),
-            format(%1%n%2)
+            format(%1%n%2), update(ListRef:set)
           ]
   syntax ListRef ::= ".ListRef"
           [ function, total, hook(LIST.unit), symbol(.ListRef),


### PR DESCRIPTION
This fixes the issue where the llvm backend crashed when trying to build with the latest version of K.