### PR TITLE
Add ULM build integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 .envrc
 result
+
+build

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,116 @@ clean: pykwasm
 	$(KDIST) clean
 
 
+# Building ULM-integrated Definition
+# ----------------------------------
+
+ULM_BUILD_DIR=./build
+ULM_LIB_DIR=$(ULM_BUILD_DIR)/lib
+ULM_DEP_DIR=$(ULM_BUILD_DIR)/deps
+ULM_CXX=$(shell [ $(origin CXX) != default ] && echo $(CXX) )
+ULM_KF_INCLUDE_DIR=$(shell dirname "`which llvm-kompile`")/../include
+
+ULM_WASM_DIR=$(ULM_BUILD_DIR)/wasm
+ULM_WASM_MAIN=pykwasm/src/pykwasm/kdist/wasm-semantics/wasm.md
+ULM_WASM_LIB=libkwasm.so
+ULM_WASM_TARGET=$(ULM_LIB_DIR)/$(ULM_WASM_LIB)
+
+ULM_WASM_COMPILER_TARGET=$(ULM_BUILD_DIR)/ulm-contract-compiler
+
+ULM_PLUGIN_DIR=$(ULM_DEP_DIR)/plugin
+ULM_PLUGIN_LIB=krypto.a
+ULM_PLUGIN_TARGET=$(ULM_LIB_DIR)/$(ULM_PLUGIN_LIB)
+
+ULM_HOOKS_CLONE_DIR=$(ULM_DEP_DIR)/ulm
+ULM_HOOKS_DIR=$(ULM_HOOKS_CLONE_DIR)/kllvm
+ULM_HOOKS_SRC=ulm_kllvm.cpp ulm_hooks.cpp ulm_kllvm_c.cpp
+ULM_HOOKS_LIB=libulmkllvm.so
+ULM_HOOKS_TARGET=$(ULM_LIB_DIR)/$(ULM_HOOKS_LIB)
+
+### ULM Plugin
+
+$(ULM_PLUGIN_DIR)/.git:
+	@mkdir -p $(ULM_DEP_DIR)
+	cd $(ULM_DEP_DIR); \
+	  git clone https://github.com/runtimeverification/blockchain-k-plugin plugin; \
+	  cd plugin; \
+	  git submodule update --init --recursive
+
+$(ULM_PLUGIN_TARGET): | $(ULM_PLUGIN_DIR)/.git
+	@mkdir -p $(ULM_LIB_DIR)
+	cd $(ULM_PLUGIN_DIR); \
+	  $(if $(ULM_CXX), CXX=$(ULM_CXX)) make build
+	cp "$(ULM_PLUGIN_DIR)/build/krypto/lib/krypto.a" "$(ULM_LIB_DIR)"
+
+.PHONY: ulm-plugin-build
+ulm-plugin-build: $(ULM_PLUGIN_TARGET)
+
+### ULM Hooks
+
+$(ULM_HOOKS_CLONE_DIR)/.git:
+	@mkdir -p $(ULM_DEP_DIR)
+	cd $(ULM_DEP_DIR); \
+	  git clone https://github.com/pi-squared-inc/ulm
+
+$(ULM_HOOKS_TARGET): | $(ULM_HOOKS_CLONE_DIR)/.git
+	@mkdir -p $(ULM_LIB_DIR)
+	cd $(ULM_HOOKS_DIR); \
+	  $(CXX) -shared -o "$(ULM_HOOKS_LIB_NAME)" $(ULM_HOOKS_SRC) -I "$(ULM_KF_INCLUDE_DIR)" -I "$(ULM_KF_INCLUDE_DIR)/kllvm" \
+	    -fPIC -lcryptopp -lgmp -std=c++20 -Wall -Werror -g -fno-omit-frame-pointer -Wno-return-type-c-linkage $(CPPFLAGS)
+	cp "$(ULM_HOOKS_DIR)/$(ULM_HOOKS_LIB_NAME)" "$(ULM_LIB_DIR)"
+
+.PHONY: ulm-hooks-build
+ulm-hooks-build: $(ULM_HOOKS_TARGET)
+
+### ULM Wasm
+
+$(ULM_WASM_TARGET): $(ULM_PLUGIN_TARGET) $(ULM_HOOKS_TARGET)
+	kompile \
+	  --hook-namespaces 'KRYPTO ULM' \
+	  -O2 \
+	  -ccopt -g \
+	  -ccopt -std=c++20 \
+	  -ccopt -lcrypto \
+	  -ccopt -lsecp256k1 \
+	  -ccopt -lssl \
+	  -ccopt "$(ULM_PLUGIN_TARGET)" \
+	  -ccopt -L"$(ULM_LIB_DIR)" \
+	  -ccopt -lulmkllvm \
+	  -ccopt "$(ULM_HOOKS_DIR)/lang/ulm_language_entry.cpp" \
+	  -ccopt -I"$(ULM_HOOKS_DIR)" \
+	  -ccopt -DULM_LANG_ID=wasm \
+	  -ccopt -shared \
+	  -ccopt -fPIC \
+	  --llvm-hidden-visibility \
+	  --llvm-kompile-type library \
+	  --llvm-kompile-output "$(ULM_WASM_LIB)" \
+	  -I "$(ULM_HOOKS_DIR)" \
+	  -I "$(ULM_PLUGIN_DIR)/plugin" \
+	  -v \
+	  $(ULM_WASM_MAIN) \
+	  -o $(ULM_WASM_DIR)
+	cp "$(ULM_WASM_DIR)/$(ULM_WASM_LIB)" "$(ULM_LIB_DIR)"
+
+.PHONY: ulm-wasm
+ulm-wasm: $(ULM_WASM_TARGET)
+
+### ULM Wasm Contract Compiler
+
+$(ULM_WASM_COMPILER_TARGET): $(ULM_WASM_TARGET)
+	$(CXX) "$(ULM_HOOKS_DIR)/emit_contract_bytes.cpp" \
+	  -I "$(ULM_KF_INCLUDE_DIR)" \
+	  -I "$(ULM_KF_INCLUDE_DIR)/kllvm" \
+	  -std=c++20 \
+	  -DULM_LANG_ID=wasm \
+	  -Wno-return-type-c-linkage \
+	  -L"$(ULM_LIB_DIR)" \
+	  -lulmkllvm \
+	  -lkwasm \
+	  -o "$(ULM_WASM_COMPILER_TARGET)"
+
+.PHONY: ulm-contract-compiler
+ulm-contract-compiler: $(ULM_WASM_COMPILER_TARGET)
+
 # Testing
 # -------
 

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,11 @@ ULM_CXX=$(shell [ $(origin CXX) != default ] && echo $(CXX) )
 ULM_KF_INCLUDE_DIR=$(shell dirname "`which llvm-kompile`")/../include
 
 ULM_WASM_DIR=$(ULM_BUILD_DIR)/wasm
-ULM_WASM_MAIN=pykwasm/src/pykwasm/kdist/wasm-semantics/ulm-wasm.md
+ULM_WASM_SRC_DIR=pykwasm/src/pykwasm/kdist/wasm-semantics
 ULM_WASM_LIB=libkwasm.so
 ULM_WASM_TARGET=$(ULM_LIB_DIR)/$(ULM_WASM_LIB)
+ULM_WASM_MAIN=$(ULM_WASM_SRC_DIR)/ulm-wasm.md
+ULM_WASM_SRC=$(wildcard $(ULM_WASM_SRC_DIR)/*.md $(ULM_WASM_SRC_DIR)/data/*.k)
 
 ULM_WASM_COMPILER_TARGET=$(ULM_BUILD_DIR)/ulm-contract-compiler
 
@@ -92,7 +94,7 @@ ulm-hooks-build: $(ULM_HOOKS_TARGET)
 
 ### ULM Wasm
 
-$(ULM_WASM_TARGET): $(ULM_PLUGIN_TARGET) $(ULM_HOOKS_TARGET)
+$(ULM_WASM_TARGET): $(ULM_PLUGIN_TARGET) $(ULM_HOOKS_TARGET) $(ULM_WASM_SRC)
 	kompile \
 	  --hook-namespaces 'KRYPTO ULM' \
 	  -O2 \

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ ULM_HOOKS_TARGET=$(ULM_LIB_DIR)/$(ULM_HOOKS_LIB)
 $(ULM_KRYPTO_DIR)/.git:
 	@mkdir -p $(ULM_DEP_DIR)
 	cd $(ULM_DEP_DIR); \
-	  git clone https://github.com/runtimeverification/blockchain-k-plugin plugin; \
+	  git clone --depth 1 https://github.com/runtimeverification/blockchain-k-plugin plugin; \
 	  cd plugin; \
 	  git submodule update --init --recursive
 
@@ -79,7 +79,7 @@ ulm-krypto-build: $(ULM_KRYPTO_TARGET)
 $(ULM_HOOKS_CLONE_DIR)/.git:
 	@mkdir -p $(ULM_DEP_DIR)
 	cd $(ULM_DEP_DIR); \
-	  git clone https://github.com/pi-squared-inc/ulm
+	  git clone --depth 1 https://github.com/pi-squared-inc/ulm
 
 $(ULM_HOOKS_TARGET): | $(ULM_HOOKS_CLONE_DIR)/.git
 	@mkdir -p $(ULM_LIB_DIR)

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ULM_CXX=$(shell [ $(origin CXX) != default ] && echo $(CXX) )
 ULM_KF_INCLUDE_DIR=$(shell dirname "`which llvm-kompile`")/../include
 
 ULM_WASM_DIR=$(ULM_BUILD_DIR)/wasm
-ULM_WASM_MAIN=pykwasm/src/pykwasm/kdist/wasm-semantics/wasm.md
+ULM_WASM_MAIN=pykwasm/src/pykwasm/kdist/wasm-semantics/ulm-wasm.md
 ULM_WASM_LIB=libkwasm.so
 ULM_WASM_TARGET=$(ULM_LIB_DIR)/$(ULM_WASM_LIB)
 

--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,9 @@ $(ULM_HOOKS_CLONE_DIR)/.git:
 $(ULM_HOOKS_TARGET): | $(ULM_HOOKS_CLONE_DIR)/.git
 	@mkdir -p $(ULM_LIB_DIR)
 	cd $(ULM_HOOKS_DIR); \
-	  $(CXX) -shared -o "$(ULM_HOOKS_LIB_NAME)" $(ULM_HOOKS_SRC) -I "$(ULM_KF_INCLUDE_DIR)" -I "$(ULM_KF_INCLUDE_DIR)/kllvm" \
+	  $(CXX) -shared -o "$(ULM_HOOKS_LIB)" $(ULM_HOOKS_SRC) -I "$(ULM_KF_INCLUDE_DIR)" -I "$(ULM_KF_INCLUDE_DIR)/kllvm" \
 	    -fPIC -lcryptopp -lgmp -std=c++20 -Wall -Werror -g -fno-omit-frame-pointer -Wno-return-type-c-linkage $(CPPFLAGS)
-	cp "$(ULM_HOOKS_DIR)/$(ULM_HOOKS_LIB_NAME)" "$(ULM_LIB_DIR)"
+	cp "$(ULM_HOOKS_DIR)/$(ULM_HOOKS_LIB)" "$(ULM_LIB_DIR)"
 
 .PHONY: ulm-hooks-build
 ulm-hooks-build: $(ULM_HOOKS_TARGET)

--- a/pykwasm/src/pykwasm/kdist/wasm-semantics/ulm-wasm.md
+++ b/pykwasm/src/pykwasm/kdist/wasm-semantics/ulm-wasm.md
@@ -1,0 +1,17 @@
+```k
+requires "wasm.md"
+requires "ulm.k"
+```
+
+```k
+module ULM-WASM-SYNTAX
+  imports WASM-SYNTAX
+endmodule
+```
+
+```k
+module ULM-WASM
+  imports WASM
+  imports ULM
+endmodule
+```

--- a/pykwasm/src/pykwasm/kdist/wasm-semantics/ulm-wasm.md
+++ b/pykwasm/src/pykwasm/kdist/wasm-semantics/ulm-wasm.md
@@ -1,5 +1,5 @@
 ```k
-requires "wasm.md"
+requires "wasm-text.md"
 requires "ulm.k"
 ```
 
@@ -11,7 +11,11 @@ endmodule
 
 ```k
 module ULM-WASM
-  imports WASM
+  imports WASM-TEXT
   imports ULM
+
+  configuration <ulm-wasm>
+                  <wasm/>
+                </ulm-wasm>
 endmodule
 ```

--- a/scripts/compile-contract
+++ b/scripts/compile-contract
@@ -1,0 +1,4 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+LD_LIBRARY_PATH="$SCRIPT_DIR/../build/lib:$LD_LIBRARY_PATH" "$SCRIPT_DIR/../build/ulm-contract-compiler"


### PR DESCRIPTION
Several changes:

1. there is a new K WASM main file that imports the ULM hooks 
2. the makefile now contains targets to build ULM-integrated WASM in a separate build directory
3. the git ignore file was updated to exclude the build directory

closes: #14