### PR TITLE
Implement storage access for contracts written in Rust

### DIFF
--- a/tests/ulm/erc20/rust/src/decoder.rs
+++ b/tests/ulm/erc20/rust/src/decoder.rs
@@ -17,7 +17,7 @@
 // let (value_n, decoder) = decoder.decode();
 //
 // At the end, it's good practice to check that you have decoded everything
-// you wanted. The following will not compile if decoding didn't finish.    
+// you wanted. The following will not compile if decoding didn't finish.
 //
 // decoder.check_done();
 

--- a/tests/ulm/erc20/rust/src/encoder.rs
+++ b/tests/ulm/erc20/rust/src/encoder.rs
@@ -27,7 +27,7 @@ pub trait Encodable {
 impl Encodable for String {
     fn encode(&self) -> (EncodingType, Bytes) {
         let bytes = self.as_bytes();
-        let total_bytes_length = 32 + ((bytes.len() + 31) / 32) * 32; 
+        let total_bytes_length = 32 + ((bytes.len() + 31) / 32) * 32;
         let mut result = BytesMut::with_capacity(total_bytes_length);
         let (_, len_bytes) = U256::from_u64(bytes.len() as u64).encode();
 

--- a/tests/ulm/erc20/rust/src/lib.rs
+++ b/tests/ulm/erc20/rust/src/lib.rs
@@ -2,7 +2,9 @@ mod assertions;
 mod decoder;
 mod encoder;
 mod predicate;
+mod storage;
 mod unsigned;
+mod ulm;
 mod ulm_hooks;
 
 mod encoding_tests;

--- a/tests/ulm/erc20/rust/src/lib.rs
+++ b/tests/ulm/erc20/rust/src/lib.rs
@@ -8,4 +8,5 @@ mod ulm;
 mod ulm_hooks;
 
 mod encoding_tests;
+mod storage_tests;
 mod unsigned_tests;

--- a/tests/ulm/erc20/rust/src/storage.rs
+++ b/tests/ulm/erc20/rust/src/storage.rs
@@ -1,0 +1,90 @@
+// SingleChunkStorage is a class which makes it easy to work with storage
+// for objects that fit in 32 bytes. Accessing storage will crash (fail) if
+// the stored bytes cannot be converted to the value type.
+//
+// Let's say you want to access a storage object under the name N, with
+// key (K1, K2, ..., Kn) and with type T. You need the following:
+// * K1 ..., Kn must implement Encodable
+// * T must implement TryFrom<U256> and Into<U256>
+//
+// Then you can build the storage object like this:
+// 
+// let mut builder = SingleChunkStorageBuilder::<MyValueType>::new(&("Storage name".to_string()))
+// builder.add_arg(K1);
+// builder.add_arg(K2);
+// ...
+// builder.add_arg(Kn);
+// let storage = builder.build();
+//
+// In order to set the storage value, do this:
+//
+// storage.set(&my_value);
+//
+// In order to get the stored value, do this:
+//
+// let my_value = storage.get();
+
+use core::marker::PhantomData;
+use std::convert::TryFrom;
+use std::convert::Into;
+
+use crate::assertions::fail;
+use crate::encoder::Encodable;
+use crate::encoder::Encoder;
+use crate::unsigned::U256;
+use crate::ulm;
+use crate::ulm_hooks;
+
+pub struct SingleChunkStorage<ValueType:Into<U256> + TryFrom<U256> + 'static> {
+    phantom: PhantomData<ValueType>,
+    fingerprint: U256,
+}
+
+impl<ValueType:Into<U256> + TryFrom<U256, Error = &'static str>> SingleChunkStorage<ValueType> {
+    pub fn new(fingerprint: U256) -> Self {
+        SingleChunkStorage::<ValueType> { phantom: PhantomData, fingerprint }
+    }
+
+    pub fn set(&self, value: ValueType) {
+        let converted: U256 = value.into();
+        ulm::set_account_storage(&self.fingerprint, &converted);
+    }
+
+    pub fn get(&self) -> ValueType {
+        let u256 = ulm::get_account_storage(&self.fingerprint);
+        match u256.try_into() {
+            Ok(v) => v,
+            Err(reason) => fail(reason), 
+        }
+    }
+}
+
+pub struct SingleChunkStorageBuilder<ValueType:Into<U256> + TryFrom<U256> + 'static> {
+    phantom: PhantomData<ValueType>,
+    encoder: Encoder,
+}
+
+impl<ValueType:Into<U256> + TryFrom<U256, Error = &'static str>> SingleChunkStorageBuilder<ValueType> {
+    pub fn new(name: &String) -> Self {
+        let mut encoder = Encoder::new();
+        encoder.add(name);
+        Self::from_encoder(encoder)
+    }
+
+    fn from_encoder(encoder: Encoder) -> Self {
+        SingleChunkStorageBuilder::<ValueType> {
+            phantom: PhantomData,
+            encoder
+        }
+    }
+
+    pub fn add_arg(&mut self, arg: &dyn Encodable) {
+        self.encoder.add(arg);
+    }
+
+    pub fn build(&self) -> SingleChunkStorage<ValueType> {
+        let bytes = self.encoder.encode();
+        let fingerprint = ulm_hooks::keccak_hash_int(&bytes);
+        SingleChunkStorage::new(fingerprint)
+    }
+}

--- a/tests/ulm/erc20/rust/src/storage.rs
+++ b/tests/ulm/erc20/rust/src/storage.rs
@@ -8,7 +8,7 @@
 // * T must implement TryFrom<U256> and Into<U256>
 //
 // Then you can build the storage object like this:
-// 
+//
 // let mut builder = SingleChunkStorageBuilder::<MyValueType>::new(&("Storage name".to_string()))
 // builder.add_arg(K1);
 // builder.add_arg(K2);
@@ -35,46 +35,61 @@ use crate::unsigned::U256;
 use crate::ulm;
 use crate::ulm_hooks;
 
-pub struct SingleChunkStorage<ValueType:Into<U256> + TryFrom<U256> + 'static> {
-    phantom: PhantomData<ValueType>,
+pub struct SingleChunkStorage<'a, ValueType>
+    where
+        ValueType: Into<U256> + TryFrom<U256>,
+{
+    phantom_value: PhantomData<&'a ValueType>,
+    api: &'a mut dyn ulm::Ulm,
     fingerprint: U256,
 }
 
-impl<ValueType:Into<U256> + TryFrom<U256, Error = &'static str>> SingleChunkStorage<ValueType> {
-    pub fn new(fingerprint: U256) -> Self {
-        SingleChunkStorage::<ValueType> { phantom: PhantomData, fingerprint }
+impl<'a, ValueType> SingleChunkStorage<'a, ValueType>
+    where
+        ValueType: Into<U256> + TryFrom<U256, Error = &'static str>,
+{
+    pub fn new(api: &'a mut dyn ulm::Ulm, fingerprint: U256) -> Self {
+        SingleChunkStorage::<ValueType> { phantom_value: PhantomData, api, fingerprint }
     }
 
-    pub fn set(&self, value: ValueType) {
+    pub fn set(&mut self, value: ValueType) {
         let converted: U256 = value.into();
-        ulm::set_account_storage(&self.fingerprint, &converted);
+        ulm::set_account_storage(self.api, &self.fingerprint, &converted);
     }
 
     pub fn get(&self) -> ValueType {
-        let u256 = ulm::get_account_storage(&self.fingerprint);
+        let u256 = ulm::get_account_storage(self.api, &self.fingerprint);
         match u256.try_into() {
             Ok(v) => v,
-            Err(reason) => fail(reason), 
+            Err(reason) => fail(reason),
         }
     }
 }
 
-pub struct SingleChunkStorageBuilder<ValueType:Into<U256> + TryFrom<U256> + 'static> {
-    phantom: PhantomData<ValueType>,
+pub struct SingleChunkStorageBuilder<'a, ValueType>
+    where
+        ValueType: Into<U256> + TryFrom<U256>,
+{
+    phantom_value: PhantomData<&'a ValueType>,
+    api: &'a mut dyn ulm::Ulm,
     encoder: Encoder,
 }
 
-impl<ValueType:Into<U256> + TryFrom<U256, Error = &'static str>> SingleChunkStorageBuilder<ValueType> {
-    pub fn new(name: &String) -> Self {
+impl<'a, ValueType> SingleChunkStorageBuilder<'a, ValueType>
+    where
+        ValueType: Into<U256> + TryFrom<U256, Error = &'static str>,
+{
+    pub fn new(api: &'a mut dyn ulm::Ulm, name: &String) -> Self {
         let mut encoder = Encoder::new();
         encoder.add(name);
-        Self::from_encoder(encoder)
+        Self::from_encoder(api, encoder)
     }
 
-    fn from_encoder(encoder: Encoder) -> Self {
+    fn from_encoder(api: &'a mut dyn ulm::Ulm, encoder: Encoder) -> Self {
         SingleChunkStorageBuilder::<ValueType> {
-            phantom: PhantomData,
-            encoder
+            phantom_value: PhantomData,
+            api,
+            encoder,
         }
     }
 
@@ -82,9 +97,9 @@ impl<ValueType:Into<U256> + TryFrom<U256, Error = &'static str>> SingleChunkStor
         self.encoder.add(arg);
     }
 
-    pub fn build(&self) -> SingleChunkStorage<ValueType> {
+    pub fn build(&mut self) -> SingleChunkStorage<ValueType> {
         let bytes = self.encoder.encode();
         let fingerprint = ulm_hooks::keccak_hash_int(&bytes);
-        SingleChunkStorage::new(fingerprint)
+        SingleChunkStorage::new(self.api, fingerprint)
     }
 }

--- a/tests/ulm/erc20/rust/src/storage.rs
+++ b/tests/ulm/erc20/rust/src/storage.rs
@@ -9,12 +9,12 @@
 //
 // Then you can build the storage object like this:
 //
-// let mut builder = SingleChunkStorageBuilder::<MyValueType>::new(&("Storage name".to_string()))
+// let mut builder = SingleChunkStorageBuilder::<MyValueType>::new(api, hooks_api, &("Storage name".to_string()))
 // builder.add_arg(K1);
 // builder.add_arg(K2);
 // ...
 // builder.add_arg(Kn);
-// let storage = builder.build();
+// let mut storage = builder.build();
 //
 // In order to set the storage value, do this:
 //

--- a/tests/ulm/erc20/rust/src/storage_tests.rs
+++ b/tests/ulm/erc20/rust/src/storage_tests.rs
@@ -1,0 +1,102 @@
+#[cfg(test)]
+mod encoding_tests {
+    use crate::storage::*;
+    use crate::ulm;
+    use crate::ulm_hooks;
+    use crate::unsigned::*;
+
+    #[test]
+    fn read_value_not_set() {
+        let api = ulm::mock::UlmMock::new();
+        let hooks_api = ulm_hooks::mock::UlmHooksMock::new();
+        let mut builder = SingleChunkStorageBuilder::<U256>::new(api, hooks_api, &("my_storage".to_string()));
+
+        let storage = builder.build();
+        let value: U256 = storage.get();
+
+        assert_eq!(U256::from_u64(0), value);
+    }
+
+    #[test]
+    fn write_read_u256() {
+        let api = ulm::mock::UlmMock::new();
+        let hooks_api = ulm_hooks::mock::UlmHooksMock::new();
+        let mut builder = SingleChunkStorageBuilder::<U256>::new(api, hooks_api, &("my_storage".to_string()));
+
+        let mut storage = builder.build();
+        storage.set(U256::from_u64(123456789));
+        let value: U256 = storage.get();
+
+        assert_eq!(U256::from_u64(123456789), value);
+    }
+
+    #[test]
+    fn write_read_u8() {
+        let api = ulm::mock::UlmMock::new();
+        let hooks_api = ulm_hooks::mock::UlmHooksMock::new();
+        let mut builder = SingleChunkStorageBuilder::<Unsigned::<1>>::new(api, hooks_api, &("my_storage".to_string()));
+
+        let mut storage = builder.build();
+        storage.set(Unsigned::<1>::from_u64(123));
+        let value: Unsigned<1> = storage.get();
+
+        assert_eq!(Unsigned::<1>::from_u64(123), value);
+    }
+
+    #[test]
+    fn write_read_args() {
+        let api = ulm::mock::UlmMock::new();
+        let hooks_api = ulm_hooks::mock::UlmHooksMock::new();
+
+        let mut builder = SingleChunkStorageBuilder::<U256>::new(api, hooks_api, &("my_storage".to_string()));
+
+        builder.add_arg(&U256::from_u64(5));
+
+        let mut storage = builder.build();
+        storage.set(U256::from_u64(123456789));
+        let value: U256 = storage.get();
+
+        assert_eq!(U256::from_u64(123456789), value);
+    }
+
+    #[test]
+    fn no_confusion() {
+        let api = ulm::mock::UlmMock::new();
+        let hooks_api = ulm_hooks::mock::UlmHooksMock::new();
+
+        let mut builder1 = SingleChunkStorageBuilder::<U256>::new(api.clone(), hooks_api.clone(), &("my_storage".to_string()));
+        let mut builder2 = SingleChunkStorageBuilder::<U256>::new(api.clone(), hooks_api.clone(), &("my_storage1".to_string()));
+        let mut builder3 = SingleChunkStorageBuilder::<U256>::new(api.clone(), hooks_api.clone(), &("my_storage".to_string()));
+        let mut builder4 = SingleChunkStorageBuilder::<U256>::new(api.clone(), hooks_api.clone(), &("my_storage".to_string()));
+        let mut builder5 = SingleChunkStorageBuilder::<U256>::new(api, hooks_api, &("my_storage".to_string()));
+
+        builder3.add_arg(&U256::from_u64(3));
+        builder4.add_arg(&U256::from_u64(4));
+        builder5.add_arg(&U256::from_u64(3));
+        builder5.add_arg(&U256::from_u64(4));
+
+        let mut storage1 = builder1.build();
+        let mut storage2 = builder2.build();
+        let mut storage3 = builder3.build();
+        let mut storage4 = builder4.build();
+        let mut storage5 = builder5.build();
+
+        storage1.set(U256::from_u64(1));
+        storage2.set(U256::from_u64(2));
+        storage3.set(U256::from_u64(3));
+        storage4.set(U256::from_u64(4));
+        storage5.set(U256::from_u64(5));
+
+        let value1: U256 = storage1.get();
+        let value2: U256 = storage2.get();
+        let value3: U256 = storage3.get();
+        let value4: U256 = storage4.get();
+        let value5: U256 = storage5.get();
+
+        assert_eq!(U256::from_u64(1), value1);
+        assert_eq!(U256::from_u64(2), value2);
+        assert_eq!(U256::from_u64(3), value3);
+        assert_eq!(U256::from_u64(4), value4);
+        assert_eq!(U256::from_u64(5), value5);
+    }
+}

--- a/tests/ulm/erc20/rust/src/ulm.rs
+++ b/tests/ulm/erc20/rust/src/ulm.rs
@@ -1,0 +1,37 @@
+use crate::unsigned::U256;
+
+extern "C" {
+    // key and value must have a length of exactly 32.
+    #[allow(non_snake_case)]
+    pub fn GetAccountStorage(key: *const u8, value: *mut u8);
+
+    // key and value must have a length of exactly 32.
+    #[allow(non_snake_case)]
+    pub fn SetAccountStorage(key: *const u8, value: *const u8);
+}
+
+pub fn get_account_storage_helper(key: &[u8; 32], value: &mut [u8; 32]) {
+    unsafe { GetAccountStorage(key.as_ptr(), value.as_mut_ptr()); }
+}
+pub fn get_account_storage(key: &U256) -> U256 {
+    let mut key_bytes = [0_u8; 32];
+    key.copy_to_array_le(&mut key_bytes);
+
+    let mut value_bytes = [0_u8; 32];
+    get_account_storage_helper(&key_bytes, &mut value_bytes);
+
+    U256::from_array_le(value_bytes)
+}
+
+pub fn set_account_storage_helper(key: &[u8; 32], value: &[u8; 32]) {
+    unsafe { SetAccountStorage(key.as_ptr(), value.as_ptr()); }
+}
+pub fn set_account_storage(key: &U256, value: &U256) {
+    let mut key_bytes = [0_u8; 32];
+    key.copy_to_array_le(&mut key_bytes);
+
+    let mut value_bytes = [0_u8; 32];
+    value.copy_to_array_le(&mut value_bytes);
+
+    set_account_storage_helper(&key_bytes, &value_bytes);
+}

--- a/tests/ulm/erc20/rust/src/ulm.rs
+++ b/tests/ulm/erc20/rust/src/ulm.rs
@@ -10,28 +10,81 @@ extern "C" {
     pub fn SetAccountStorage(key: *const u8, value: *const u8);
 }
 
-pub fn get_account_storage_helper(key: &[u8; 32], value: &mut [u8; 32]) {
-    unsafe { GetAccountStorage(key.as_ptr(), value.as_mut_ptr()); }
+pub trait Ulm {
+    fn get_account_storage(&self, key: &[u8; 32], value: &mut [u8; 32]);
+    fn set_account_storage(&mut self, key: &[u8; 32], value: &[u8; 32]);
 }
-pub fn get_account_storage(key: &U256) -> U256 {
+
+#[cfg(not(test))]
+struct UlmImpl {}
+
+#[cfg(not(test))]
+impl Ulm for UlmImpl {
+    fn get_account_storage(&self, key: &[u8; 32], value: &mut [u8; 32]) {
+        unsafe { GetAccountStorage(key.as_ptr(), value.as_mut_ptr()); }
+    }
+
+    fn set_account_storage(&mut self, key: &[u8; 32], value: &[u8; 32]) {
+        unsafe { SetAccountStorage(key.as_ptr(), value.as_ptr()); }
+    }
+}
+
+#[cfg(test)]
+mod ulm_mock {
+    use bytes::{Bytes, Buf};
+    use std::collections::HashMap;
+
+    use crate::assertions::fail;
+    use crate::require;
+    use crate::ulm::Ulm;
+
+    pub struct UlmMock {
+        storage: HashMap<Bytes, Bytes>,
+    }
+
+    impl UlmMock {
+        pub fn new() -> UlmMock {
+            UlmMock { storage: HashMap::new() }
+        }
+    }
+
+    impl Ulm for UlmMock {
+        fn get_account_storage(&self, key: &[u8; 32], value: &mut [u8; 32]) {
+            let bytes_key = Bytes::copy_from_slice(key);
+            match self.storage.get(&bytes_key) {
+                Some(v) => {
+                    let bytes_value = v.chunk();
+                    require!(bytes_value.len() == 32, "unexpected value length in storage");
+                    value.copy_from_slice(bytes_value);
+                },
+                None => fail("Key not found in storage"),
+            }
+        }
+
+        fn set_account_storage(&mut self, key: &[u8; 32], value: &[u8; 32]) {
+            let bytes_key = Bytes::copy_from_slice(key);
+            let bytes_value = Bytes::copy_from_slice(value);
+            self.storage.insert(bytes_key, bytes_value);
+        }
+    }
+}
+
+pub fn get_account_storage(api: &dyn Ulm, key: &U256) -> U256 {
     let mut key_bytes = [0_u8; 32];
     key.copy_to_array_le(&mut key_bytes);
 
     let mut value_bytes = [0_u8; 32];
-    get_account_storage_helper(&key_bytes, &mut value_bytes);
+    api.get_account_storage(&key_bytes, &mut value_bytes);
 
     U256::from_array_le(value_bytes)
 }
 
-pub fn set_account_storage_helper(key: &[u8; 32], value: &[u8; 32]) {
-    unsafe { SetAccountStorage(key.as_ptr(), value.as_ptr()); }
-}
-pub fn set_account_storage(key: &U256, value: &U256) {
+pub fn set_account_storage(api: &mut dyn Ulm, key: &U256, value: &U256) {
     let mut key_bytes = [0_u8; 32];
     key.copy_to_array_le(&mut key_bytes);
 
     let mut value_bytes = [0_u8; 32];
     value.copy_to_array_le(&mut value_bytes);
 
-    set_account_storage_helper(&key_bytes, &value_bytes);
+    api.set_account_storage(&key_bytes, &value_bytes);
 }

--- a/tests/ulm/erc20/rust/src/ulm_hooks.rs
+++ b/tests/ulm/erc20/rust/src/ulm_hooks.rs
@@ -2,6 +2,7 @@ use bytes::{Bytes, Buf};
 
 use crate::unsigned::U256;
 
+#[cfg(not(test))]
 extern "C" {
     #[allow(dead_code)]
     pub fn fail(msg: *const u8, msg_len: usize) -> !;
@@ -35,28 +36,35 @@ pub trait UlmHooks {
     fn keccak_hash(&self, value: &[u8], result: &mut [u8; 32]);
 }
 
+#[cfg(not(test))]
 struct UlmHooksImpl {
 }
 
+#[cfg(not(test))]
 impl UlmHooksImpl {
     pub fn new() -> Self {
         UlmHooksImpl {}
     }
 }
 
+#[cfg(not(test))]
 impl UlmHooks for UlmHooksImpl {
     fn keccak_hash(&self, value: &[u8], result: &mut [u8; 32]) {
         unsafe { keccakHash(value.as_ptr(), value.len(), result.as_mut_ptr()); }
     }
 }
 
-mod mock {
+#[cfg(test)]
+pub mod mock {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
     use crate::ulm_hooks::UlmHooks;
 
-    struct UlmHooksMock {}
+    pub struct UlmHooksMock {}
     impl UlmHooksMock {
-        pub fn new() -> Self {
-            UlmHooksMock {}
+        pub fn new() -> Rc<RefCell<Self>> {
+            Rc::new(RefCell::new(UlmHooksMock {}))
         }
     }
     impl UlmHooks for UlmHooksMock {

--- a/tests/ulm/erc20/rust/src/ulm_hooks.rs
+++ b/tests/ulm/erc20/rust/src/ulm_hooks.rs
@@ -31,18 +31,54 @@ pub fn failWrapper(msg: &str) -> ! {
     unsafe { fail(msg_bytes.as_ptr(), msg_bytes.len()); }
 }
 
-pub fn keccak_hash_helper(value: &[u8], result: &mut [u8; 32]) {
-    unsafe { keccakHash(value.as_ptr(), value.len(), result.as_mut_ptr()); }
+pub trait UlmHooks {
+    fn keccak_hash(&self, value: &[u8], result: &mut [u8; 32]);
 }
 
-pub fn keccak_hash(value: &Bytes) -> [u8; 32] {
+struct UlmHooksImpl {
+}
+
+impl UlmHooksImpl {
+    pub fn new() -> Self {
+        UlmHooksImpl {}
+    }
+}
+
+impl UlmHooks for UlmHooksImpl {
+    fn keccak_hash(&self, value: &[u8], result: &mut [u8; 32]) {
+        unsafe { keccakHash(value.as_ptr(), value.len(), result.as_mut_ptr()); }
+    }
+}
+
+mod mock {
+    use crate::ulm_hooks::UlmHooks;
+
+    struct UlmHooksMock {}
+    impl UlmHooksMock {
+        pub fn new() -> Self {
+            UlmHooksMock {}
+        }
+    }
+    impl UlmHooks for UlmHooksMock {
+        fn keccak_hash(&self, value: &[u8], result: &mut [u8; 32]) {
+            for i in 1 .. result.len() {
+                result[i] = 0;
+            }
+            for i in 1 .. value.len() {
+                result[i % 32] ^= value[i];
+            }
+        }
+    }
+}
+
+pub fn keccak_hash(api: &dyn UlmHooks, value: &Bytes) -> [u8; 32] {
     let mut fingerprint = [0_u8; 32];
-    keccak_hash_helper(value.chunk(), &mut fingerprint);
+    api.keccak_hash(value.chunk(), &mut fingerprint);
     fingerprint
 }
 
 
-pub fn keccak_hash_int(value: &Bytes) -> U256 {
-    let fingerprint = keccak_hash(value);
+pub fn keccak_hash_int(api: &dyn UlmHooks, value: &Bytes) -> U256 {
+    let fingerprint = keccak_hash(api, value);
     U256::from_array_le(fingerprint)
 }

--- a/tests/ulm/erc20/rust/src/ulm_hooks.rs
+++ b/tests/ulm/erc20/rust/src/ulm_hooks.rs
@@ -1,6 +1,13 @@
+use bytes::{Bytes, Buf};
+
+use crate::unsigned::U256;
+
 extern "C" {
     #[allow(dead_code)]
     pub fn fail(msg: *const u8, msg_len: usize) -> !;
+
+    // result must have a length of exactly 32.
+    pub fn keccakHash(msg: *const u8, msg_len: usize, result: *mut u8);
 }
 
 #[cfg(test)]
@@ -22,4 +29,20 @@ pub fn failWrapper(msg: &str) -> ! {
 pub fn failWrapper(msg: &str) -> ! {
     let msg_bytes = msg.as_bytes();
     unsafe { fail(msg_bytes.as_ptr(), msg_bytes.len()); }
+}
+
+pub fn keccak_hash_helper(value: &[u8], result: &mut [u8; 32]) {
+    unsafe { keccakHash(value.as_ptr(), value.len(), result.as_mut_ptr()); }
+}
+
+pub fn keccak_hash(value: &Bytes) -> [u8; 32] {
+    let mut fingerprint = [0_u8; 32];
+    keccak_hash_helper(value.chunk(), &mut fingerprint);
+    fingerprint
+}
+
+
+pub fn keccak_hash_int(value: &Bytes) -> U256 {
+    let fingerprint = keccak_hash(value);
+    U256::from_array_le(fingerprint)
 }

--- a/tests/ulm/erc20/rust/src/unsigned.rs
+++ b/tests/ulm/erc20/rust/src/unsigned.rs
@@ -61,6 +61,10 @@ impl<const N: usize> Unsigned<N> {
         Unsigned { chunks }
     }
 
+    pub fn from_array_le(chunks: [u8; N]) -> Unsigned<N> {
+        Unsigned { chunks }
+    }
+
     pub fn from_u64(value: u64) -> Unsigned<N> {
         if 8 <= N {
             let mut chunks = [0_u8; N];
@@ -74,6 +78,10 @@ impl<const N: usize> Unsigned<N> {
         } else {
             Unsigned::from_unsigned(&Unsigned::<8>::from_u64(value))
         }
+    }
+
+    pub fn copy_to_array_le(&self, chunks: &mut [u8; N]) {
+        chunks.copy_from_slice(&self.chunks);
     }
 
     pub fn try_to_u64(&self) -> Result<u64, &'static str> {

--- a/tests/ulm/erc20/rust/src/unsigned.rs
+++ b/tests/ulm/erc20/rust/src/unsigned.rs
@@ -44,7 +44,7 @@ pub type U160 = Unsigned<20>;
 pub type U256 = Unsigned<32>;
 
 impl<const N: usize> Unsigned<N> {
-    pub fn from_unsigned<const M: usize>(value: &Unsigned<M>) -> Unsigned<N> {
+    pub fn try_from_unsigned<const M: usize>(value: &Unsigned<M>) -> Result<Unsigned<N>, &'static str> {
         let mut chunks = [0_u8; N];
         if M <= N {
             for i in 0 .. M {
@@ -55,10 +55,12 @@ impl<const N: usize> Unsigned<N> {
                 chunks[i] = value.chunks[i];
             }
             for i in N .. M {
-                require!(value.chunks[i] == 0, "Value too large to cast");
+                if value.chunks[i] != 0 {
+                    return Err("Value too large to cast");
+                }
             }
         }
-        Unsigned { chunks }
+        Ok (Unsigned { chunks })
     }
 
     pub fn from_array_le(chunks: [u8; N]) -> Unsigned<N> {
@@ -76,7 +78,10 @@ impl<const N: usize> Unsigned<N> {
             require!(to_process == 0, "Unprocessed bits in value.");
             Unsigned { chunks }
         } else {
-            Unsigned::from_unsigned(&Unsigned::<8>::from_u64(value))
+            match Unsigned::try_from_unsigned(&Unsigned::<8>::from_u64(value)) {
+                Ok(v) => v,
+                Err(msg) => fail(msg),
+            }
         }
     }
 
@@ -133,6 +138,63 @@ impl<const N: usize> TryFrom<Unsigned<N>> for usize {
         (&value).try_into()
     }
 }
+impl<const N: usize, const M: usize> TryFrom<&Unsigned<N>> for Unsigned<M> {
+    type Error = &'static str;
+    fn try_from(value: &Unsigned<N>) -> Result<Self, Self::Error> {
+        Unsigned::try_from_unsigned(value)
+    }
+}
+
+#[macro_export]
+macro_rules! try_from_u256 {
+    ( $size:expr ) => {
+        impl TryFrom<U256> for Unsigned<$size>
+        {
+            type Error = &'static str;
+            fn try_from(value: U256) -> Result<Self, Self::Error> {
+                (&value).try_into()
+            }
+        }
+        impl From<Unsigned<$size>> for U256
+            where SmallerThan32<$size>: Satisfied
+        {
+            fn from(value: Unsigned<$size>) -> Self {
+                (&value).try_into().unwrap()
+            }
+        }
+    }
+}
+try_from_u256!(1);
+try_from_u256!(2);
+try_from_u256!(3);
+try_from_u256!(4);
+try_from_u256!(5);
+try_from_u256!(6);
+try_from_u256!(7);
+try_from_u256!(8);
+try_from_u256!(9);
+try_from_u256!(10);
+try_from_u256!(11);
+try_from_u256!(12);
+try_from_u256!(13);
+try_from_u256!(14);
+try_from_u256!(15);
+try_from_u256!(16);
+try_from_u256!(17);
+try_from_u256!(18);
+try_from_u256!(19);
+try_from_u256!(20);
+try_from_u256!(21);
+try_from_u256!(22);
+try_from_u256!(23);
+try_from_u256!(24);
+try_from_u256!(25);
+try_from_u256!(26);
+try_from_u256!(27);
+try_from_u256!(28);
+try_from_u256!(29);
+try_from_u256!(30);
+try_from_u256!(31);
 
 impl<const N: usize> Add for &Unsigned<N> {
     type Output = Unsigned<N>;
@@ -274,7 +336,10 @@ where
     SmallerThan32<N>: Satisfied
 {
     fn encode(&self) -> (EncodingType, Bytes) {
-        U256::from_unsigned(self).encode()
+        match U256::try_from_unsigned(self) {
+            Ok(v) => v.encode(),
+            Err(msg) => fail(msg),
+        }
     }
 }
 impl<const N: usize> Decodable for Unsigned<N>
@@ -289,7 +354,10 @@ where
     }
     fn decode(bytes: Bytes) -> Self {
         let value_u256 = U256::decode(bytes);
-        Unsigned::<N>::from_unsigned(&value_u256)
+        match Unsigned::<N>::try_from_unsigned(&value_u256) {
+            Ok(v) => v,
+            Err(msg) => fail(msg),
+        }
     }
 }
 

--- a/tests/ulm/erc20/rust/src/unsigned_tests.rs
+++ b/tests/ulm/erc20/rust/src/unsigned_tests.rs
@@ -71,6 +71,6 @@ mod unsigned_tests {
 
     #[test]
     fn from_unsigned() {
-        assert_eq!(U256::from_u64(5), U256::from_unsigned(&U160::from_u64(5)));
+        assert_eq!(U256::from_u64(5), U256::try_from_unsigned(&U160::from_u64(5)).unwrap());
     }
 }


### PR DESCRIPTION
This implements storage for objects that fit in U256 (i.e., objects that span a single Ethereum storage entry).

Fixes #29 
